### PR TITLE
Docker node roles

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -3,8 +3,6 @@
 # General vars
 spacewalk: 1
 vgname: VolGroup00
-lvopts:
-lvfilesystem: ext4
 
 # Jenkins vars
 jenkinssize: 10g

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -3,6 +3,8 @@
 # General vars
 spacewalk: 1
 vgname: VolGroup00
+lvopts:
+lvfilesystem: ext4
 
 # Jenkins vars
 jenkinssize: 10g

--- a/ansible/idr-deployment.yml
+++ b/ansible/idr-deployment.yml
@@ -1,0 +1,6 @@
+---
+# Playbook for maintaining IDR Docker nodes
+
+- hosts: idr-docker
+  roles:
+  - role: docker

--- a/ansible/idr-deployment.yml
+++ b/ansible/idr-deployment.yml
@@ -4,3 +4,4 @@
 - hosts: idr-docker
   roles:
   - role: docker
+  - role: samba-client

--- a/ansible/idr-deployment.yml
+++ b/ansible/idr-deployment.yml
@@ -4,4 +4,6 @@
 - hosts: idr-docker
   roles:
   - role: docker
+  - role: docker-dns-server
+  - role: docker-dns-client
   - role: samba-client

--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -8,3 +8,7 @@
     lvname: scratch
     lvmount: /scratch
     lvsize: "{{ scratchsize }}"
+  - role: lvm-partition
+    lvname: idrdata1
+    lvmount: /idr
+    lvsize: "{{ idrvolumesize }}"

--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -1,0 +1,7 @@
+---
+# Playbook for provisioning Jenkins CI nodes
+
+- hosts: idr-docker
+  roles:
+  - role: docker-storage
+  - role: docker

--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -1,7 +1,10 @@
 ---
-# Playbook for provisioning Jenkins CI nodes
+# Playbook for provisioning IDR Docker nodes
 
 - hosts: idr-docker
   roles:
   - role: docker-storage
-  - role: docker
+  - role: lvm-partition
+    lvname: scratch
+    lvmount: /scratch
+    lvsize: "{{ scratchsize }}"

--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -3,6 +3,7 @@
 
 - hosts: idr-docker
   roles:
+  - role: network
   - role: docker-storage
   - role: lvm-partition
     lvname: scratch

--- a/ansible/roles/docker-dns-client/tasks/main.yml
+++ b/ansible/roles/docker-dns-client/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# Setup production Docker DNS clients to run automatically
+
+- name: docker production | registrator
+  template:
+    src: systemd-docker-registrator.j2
+    dest: /etc/systemd/system/docker-registrator.service
+  register: systemdregistrator
+
+# Can't use a notifier because the reload must happen before the next step
+
+- name: reload systemd
+  command: systemctl daemon-reload
+  when: systemdregistrator.changed
+
+# service module doesn't seem to work for a new systemd.service
+
+- name: docker production | enable registrator
+  command: systemctl restart docker-registrator.service
+  when: systemdregistrator.changed

--- a/ansible/roles/docker-dns-client/templates/systemd-docker-registrator.j2
+++ b/ansible/roles/docker-dns-client/templates/systemd-docker-registrator.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Docker registrator
+Requires=docker.service
+# TODO: Should work with a remote etcd daemon
+Requires=docker-{{ dockerdns.etcd }}.service
+After=docker-{{ dockerdns.etcd }}.service
+
+[Service]
+Restart=on-failure
+RestartSec=10
+ExecStartPre=-/usr/bin/docker kill registrator
+ExecStartPre=-/usr/bin/docker rm registrator
+ExecStart=/usr/bin/docker run --name registrator \
+    --link {{ dockerdns.etcd }}:etcd \
+    -v /var/run/docker.sock:/tmp/docker.sock \
+    manics/registrator \
+    -iponly \
+    -ttl 60 \
+    -ttl-refresh=30 \
+    skydns2://etcd:2379/{{ dockerdns.domain }}
+ExecStop=/usr/bin/docker stop registrator
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/docker-dns-server/tasks/main.yml
+++ b/ansible/roles/docker-dns-server/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Setup production Docker services to run automatically
+
+- name: docker production | etcd
+  template:
+    src: systemd-docker-etcd.j2
+    dest: /etc/systemd/system/docker-{{ dockerdns.etcd }}.service
+  register: systemdetcd
+
+- name: docker production | skydns
+  template:
+    src: systemd-docker-skydns.j2
+    dest: /etc/systemd/system/docker-skydns.service
+  register: systemdskydns
+
+# Can't use a notifier because the reload must happen before the next step
+
+- name: docker production | reload systemd
+  command: systemctl daemon-reload
+  when: systemdetcd.changed or systemdskydns.changed
+
+# service module doesn't seem to work for a new systemd.service
+
+- name: docker production | enable etcd
+  command: systemctl restart docker-{{ dockerdns.etcd }}.service
+  when: systemdetcd.changed
+
+- name: docker production | enable skydns
+  command: systemctl restart docker-skydns.service
+  when: systemdskydns.changed

--- a/ansible/roles/docker-dns-server/templates/systemd-docker-etcd.j2
+++ b/ansible/roles/docker-dns-server/templates/systemd-docker-etcd.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=Docker etcd
+Requires=docker.service
+After=docker.service
+
+[Service]
+Restart=on-failure
+RestartSec=10
+ExecStartPre=-/usr/bin/docker kill {{ dockerdns.etcd }}
+ExecStartPre=-/usr/bin/docker rm {{ dockerdns.etcd }}
+#ExecStart=/usr/bin/docker run --name {{ dockerdns.etcd }} \
+#    quay.io/coreos/etcd \
+#    --listen-client-urls http://0.0.0.0:2379 \
+#    --advertise-client-urls http://0.0.0.0:2379
+ExecStart=/usr/bin/docker run --name {{ dockerdns.etcd }} \
+    quay.io/coreos/etcd:v0.4.8 \
+    -addr localhost:2379
+ExecStop=/usr/bin/docker stop {{ dockerdns.etcd }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/docker-dns-server/templates/systemd-docker-skydns.j2
+++ b/ansible/roles/docker-dns-server/templates/systemd-docker-skydns.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=Docker skydns
+Requires=docker.service
+After=docker-{{ dockerdns.etcd }}.service
+
+[Service]
+Restart=on-failure
+RestartSec=10
+ExecStartPre=-/usr/bin/docker kill skydns
+ExecStartPre=-/usr/bin/docker rm skydns
+ExecStart=/usr/bin/docker run --name skydns \
+    -p 53:53 -p 53:53/udp \
+    --link {{ dockerdns.etcd }}:etcd \
+    skynetservices/skydns \
+    -addr=0.0.0.0:53 \
+    -nameservers={{ dockerdns.forwarders }} \
+    -domain {{ dockerdns.domain }} \
+    -machines http://etcd:2379/ \
+    -verbose
+ExecStop=/usr/bin/docker stop skydns
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/docker-storage/README.md
+++ b/ansible/roles/docker-storage/README.md
@@ -1,0 +1,30 @@
+Docker Storage
+==============
+
+Setup LVM storage partitions for Docker.
+
+Creates thin-pool logical volumes for Docker, and a normal logical volume for `/var/lib/docker`.
+
+Role Variables
+--------------
+
+These variables must be defined (defaults aren't provided):
+
+- `vgname`: LVM volume group for the logical volumes
+- `dockerpoolsize`: Size of the Docker thin-pool partition
+- `dockervolumesize`: Size of the `/var/lib/docker` partition
+- `lvfilesystem`: filesystem for the Docker volume partition
+
+Optional variables:
+
+- `lvopts`: Logical volume creation options (default: None)
+
+Dependencies
+------------
+
+Depends on lvm-partition
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/docker-storage/meta/main.yml
+++ b/ansible/roles/docker-storage/meta/main.yml
@@ -1,0 +1,6 @@
+---
+dependencies:
+- role: lvm-partition
+  lvname: docker-volume
+  lvmount: /var/lib/docker
+  lvsize: "{{ dockervolumesize }}"

--- a/ansible/roles/docker-storage/tasks/main.yml
+++ b/ansible/roles/docker-storage/tasks/main.yml
@@ -1,33 +1,30 @@
 ---
 # Setup LVM partitions for Docker
 
-- name: storage | setup lvm docker-datadev
+- name: storage | setup lvm docker-pool
   lvol:
     vg: "{{ vgname }}"
-    lv: docker-datadev
-    size: "{{ docker.datasize }}"
-
-- name: storage | setup lvm docker-metadatadev
-  lvol:
-    vg: "{{ vgname }}"
-    lv: docker-metadatadev
-    size: "{{ docker.metadatasize }}"
+    lv: docker-pool
+    size: "{{ docker.poolsize }}"
+    opts: "{{ lvopts }} --thin --poolmetadatasize {{ docker.metadatasize }}"
 
 - name: storage | setup lvm docker-volume
   lvol:
     vg: "{{ vgname }}"
     lv: docker-volume
     size: "{{ docker.volumesize }}"
+    opts: "{{ lvopts }}"
 
 - name: storage | setup lvm scratch
   lvol:
     vg: "{{ vgname }}"
     lv: scratch
     size: "{{ scratchsize }}"
+    opts: "{{ lvopts }}"
 
 - name: storage | format
   filesystem:
-    fstype: ext4
+    fstype: "{{ lvfilesystem }}"
     dev: /dev/{{ vgname }}/{{ item }}
   with_items:
     - docker-volume
@@ -37,16 +34,16 @@
   mount:
     name: /scratch
     src: /dev/{{ vgname }}/scratch
-    dump: 1
-    passno: 2
-    fstype: ext4
+    dump: "1"
+    passno: "2"
+    fstype: "{{ lvfilesystem }}"
     state: mounted
 
 - name: storage | mount docker-volume
   mount:
     name: /var/lib/docker
     src: /dev/{{ vgname }}/docker-volume
-    dump: 1
-    passno: 2
-    fstype: ext4
+    dump: "1"
+    passno: "2"
+    fstype: "{{ lvfilesystem }}"
     state: mounted

--- a/ansible/roles/docker-storage/tasks/main.yml
+++ b/ansible/roles/docker-storage/tasks/main.yml
@@ -5,45 +5,5 @@
   lvol:
     vg: "{{ vgname }}"
     lv: docker-pool
-    size: "{{ docker.poolsize }}"
-    opts: "{{ lvopts }} --thin --poolmetadatasize {{ docker.metadatasize }}"
-
-- name: storage | setup lvm docker-volume
-  lvol:
-    vg: "{{ vgname }}"
-    lv: docker-volume
-    size: "{{ docker.volumesize }}"
-    opts: "{{ lvopts }}"
-
-- name: storage | setup lvm scratch
-  lvol:
-    vg: "{{ vgname }}"
-    lv: scratch
-    size: "{{ scratchsize }}"
-    opts: "{{ lvopts }}"
-
-- name: storage | format
-  filesystem:
-    fstype: "{{ lvfilesystem }}"
-    dev: /dev/{{ vgname }}/{{ item }}
-  with_items:
-    - docker-volume
-    - scratch
-
-- name: storage | mount scratch
-  mount:
-    name: /scratch
-    src: /dev/{{ vgname }}/scratch
-    dump: "1"
-    passno: "2"
-    fstype: "{{ lvfilesystem }}"
-    state: mounted
-
-- name: storage | mount docker-volume
-  mount:
-    name: /var/lib/docker
-    src: /dev/{{ vgname }}/docker-volume
-    dump: "1"
-    passno: "2"
-    fstype: "{{ lvfilesystem }}"
-    state: mounted
+    size: "{{ dockerpoolsize }}"
+    opts: "{{ lvopts }} --thin --poolmetadatasize {{ dockermetadatasize }}"

--- a/ansible/roles/docker-storage/tasks/main.yml
+++ b/ansible/roles/docker-storage/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+# Setup LVM partitions for Docker
+
+- name: storage | setup lvm docker-datadev
+  lvol:
+    vg: "{{ vgname }}"
+    lv: docker-datadev
+    size: "{{ docker.datasize }}"
+
+- name: storage | setup lvm docker-metadatadev
+  lvol:
+    vg: "{{ vgname }}"
+    lv: docker-metadatadev
+    size: "{{ docker.metadatasize }}"
+
+- name: storage | setup lvm docker-volume
+  lvol:
+    vg: "{{ vgname }}"
+    lv: docker-volume
+    size: "{{ docker.volumesize }}"
+
+- name: storage | setup lvm scratch
+  lvol:
+    vg: "{{ vgname }}"
+    lv: scratch
+    size: "{{ scratchsize }}"
+
+- name: storage | format
+  filesystem:
+    fstype: ext4
+    dev: /dev/{{ vgname }}/{{ item }}
+  with_items:
+    - docker-volume
+    - scratch
+
+- name: storage | mount scratch
+  mount:
+    name: /scratch
+    src: /dev/{{ vgname }}/scratch
+    dump: 1
+    passno: 2
+    fstype: ext4
+    state: mounted
+
+- name: storage | mount docker-volume
+  mount:
+    name: /var/lib/docker
+    src: /dev/{{ vgname }}/docker-volume
+    dump: 1
+    passno: 2
+    fstype: ext4
+    state: mounted

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -1,0 +1,33 @@
+Docker
+======
+
+Install and configure Docker. Assumes storage has been configured. Also sets up groups and users.
+
+Requirements
+------------
+
+Requires the docker-storage role to have been already run, since this disables the default Docker storage configuration.
+docker-storage is not automatically added since it involves hardware configuration.
+
+Role Variables
+--------------
+
+These variables must be defined (defaults aren't provided):
+
+- `vgname`: The volume group used in `docker-storage`. This is necessary because the docker setup process requires the name of the raw logical volume device.
+
+Optional variables:
+
+- `dockerbridge.name`: The name of a custom network bridge for docker
+- `dockerbridge.ips`: The custom IP range that docker should use for allocating IPs
+- `dockergroupmembers`: A list of users who will be added to the `docker` system group
+
+Dependencies
+------------
+
+The `docker-storage` role must have been run separately.
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/docker/files/docker-storage-setup
+++ b/ansible/roles/docker/files/docker-storage-setup
@@ -1,0 +1,3 @@
+# docker-storage-setup options (created by Ansible)
+# Disable the docker-storage-setup script, configure manually
+STORAGE_DRIVER=

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+# Handler for docker
+
+- name: restart docker
+  service: name=docker state=restarted

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -16,7 +16,6 @@
     backup: yes
   notify:
     - restart docker
-    # TODO: This isn't being triggered
 
 - name: docker | configure storage
   template:
@@ -25,7 +24,6 @@
     backup: yes
   notify:
     - restart docker
-    # TODO: This isn't being triggered
 
 - name: docker | configure network
   template:
@@ -35,7 +33,23 @@
   when: dockerbridge is defined
   notify:
     - restart docker
-    # TODO: This isn't being triggered
+
+# In recent versions of CentOS7 Docker the docker group isn't created
+
+- name: docker | create docker group
+  group:
+    name: docker
+    state: present
+    system: yes
+
+- name: docker | set group for docker socket
+  replace:
+    backup: yes
+    dest: /etc/sysconfig/docker
+    regexp: ^\s*OPTIONS='--selinux-enabled'\s*$
+    replace: OPTIONS='--selinux-enabled -G docker'
+  notify:
+    - restart docker
 
 - name: docker | enable
   service:
@@ -43,10 +57,10 @@
     state: started
     enabled: yes
 
-#- name: docker | group members
-#  user:
-#    name: "{{ item }}"
-#    groups: docker
-#    append: yes
-#  with_items: dockergroupmembers
-#  when: dockergroupmembers is defined
+- name: docker | group members
+  user:
+    name: "{{ item }}"
+    groups: docker
+    append: yes
+  with_items: dockergroupmembers
+  when: dockergroupmembers is defined

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+# Setup a Docker node
+
+- name: system packages | install docker
+  yum:
+    pkg: "{{ item }}"
+    state: latest
+    enablerepo: extras
+  with_items:
+    - docker
+
+- name: docker | configure storage
+  template:
+    src: docker-storage.j2
+    dest: /etc/sysconfig/docker-storage
+    backup: yes
+  notify:
+    - restart docker
+    # TODO: This isn't being triggered
+
+- name: docker | configure network
+  template:
+    src: docker-network.j2
+    dest: /etc/sysconfig/docker-network
+    backup: yes
+  when: dockerbridge is defined
+  notify:
+    - restart docker
+    # TODO: This isn't being triggered
+
+- name: docker | enable
+  service:
+    name: docker
+    state: started
+    enabled: yes
+
+- name: docker | group members
+  user:
+    name: "{{ item }}"
+    groups: docker
+    append: yes
+  with_items: dockergroupmembers
+  when: dockergroupmembers is defined

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -9,6 +9,15 @@
   with_items:
     - docker
 
+- name: docker | disable storage autoconfiguration
+  copy:
+    src: docker-storage-setup
+    dest: /etc/sysconfig/docker-storage-setup
+    backup: yes
+  notify:
+    - restart docker
+    # TODO: This isn't being triggered
+
 - name: docker | configure storage
   template:
     src: docker-storage.j2
@@ -34,10 +43,10 @@
     state: started
     enabled: yes
 
-- name: docker | group members
-  user:
-    name: "{{ item }}"
-    groups: docker
-    append: yes
-  with_items: dockergroupmembers
-  when: dockergroupmembers is defined
+#- name: docker | group members
+#  user:
+#    name: "{{ item }}"
+#    groups: docker
+#    append: yes
+#  with_items: dockergroupmembers
+#  when: dockergroupmembers is defined

--- a/ansible/roles/docker/templates/docker-network.j2
+++ b/ansible/roles/docker/templates/docker-network.j2
@@ -1,0 +1,2 @@
+# Docker network options (created by Ansible)
+DOCKER_NETWORK_OPTIONS="-b {{ dockerbridge.name }} --fixed-cidr {{ dockerbridge.ips }}"

--- a/ansible/roles/docker/templates/docker-storage.j2
+++ b/ansible/roles/docker/templates/docker-storage.j2
@@ -1,0 +1,2 @@
+# Docker storage options (created by Ansible)
+DOCKER_STORAGE_OPTIONS="--storage-opt dm.datadev=/dev/{{ vgname }}/docker-datadev --storage-opt dm.metadatadev=/dev/{{ vgname }}/docker-metadatadev --storage-opt dm.basesize={{ docker.basesize }}"

--- a/ansible/roles/docker/templates/docker-storage.j2
+++ b/ansible/roles/docker/templates/docker-storage.j2
@@ -1,2 +1,6 @@
 # Docker storage options (created by Ansible)
-DOCKER_STORAGE_OPTIONS="--storage-opt dm.datadev=/dev/{{ vgname }}/docker-datadev --storage-opt dm.metadatadev=/dev/{{ vgname }}/docker-metadatadev --storage-opt dm.basesize={{ docker.basesize }}"
+DOCKER_STORAGE_OPTIONS="\
+    --storage-driver devicemapper --storage-opt dm.fs=xfs \
+    --storage-opt dm.thinpooldev=/dev/mapper/{{ vgname }}-docker--pool \
+    --storage-opt dm.use_deferred_removal=true \
+    "

--- a/ansible/roles/lvm-partition/README.md
+++ b/ansible/roles/lvm-partition/README.md
@@ -1,0 +1,24 @@
+LVM Partition
+=============
+
+Additional LVM logical volumes to be created and mounted.
+
+Role Variables
+--------------
+
+These variables must be defined (defaults aren't provided):
+
+- `vgname`: LVM volume group for the logical volume
+- `lvname`: Logical volume name, use `[A-Aa-z0-9]+` to avoid problems
+- `lvmount`: Where the partition should be mounted
+- `lvsize`: Size of the partition
+- `lvfilesystem`: filesystem for partitions which need to be formatted
+
+Optional variables:
+
+- `lvopts`: Logical volume creation options (default: None)
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/lvm-partition/defaults/main.yml
+++ b/ansible/roles/lvm-partition/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for roles/lvm-partitions
+
+lvopts:

--- a/ansible/roles/lvm-partition/tasks/main.yml
+++ b/ansible/roles/lvm-partition/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# Setup LVM partition
+
+- name: storage | create logical volume
+  lvol:
+    vg: "{{ vgname }}"
+    lv: "{{ lvname }}"
+    size: "{{ lvsize }}"
+    opts: "{{ lvopts }}"
+
+- name: storage | format
+  filesystem:
+    fstype: "{{ lvfilesystem }}"
+    dev: /dev/{{ vgname }}/{{ lvname }}
+
+- name: storage | mount scratch
+  mount:
+    name: "{{ lvmount }}"
+    src: /dev/{{ vgname }}/{{ lvname }}
+    dump: "1"
+    passno: "2"
+    fstype: "{{ lvfilesystem }}"
+    state: mounted

--- a/ansible/roles/network/handlers/main.yml
+++ b/ansible/roles/network/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+# Handler for network configuration
+
+- name: restart network
+  service: name=network state=restarted

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# Setup network interfaces
+
+- name: network | Setup nics
+  template: src=etc-sysconfig-network-scripts-ifcfg.j2 dest=/etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
+  with_items: networkifaces
+  notify:
+    - restart network

--- a/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -1,0 +1,33 @@
+DEVICE={{ item.device }}
+BOOTPROTO=none
+IPV6INIT=yes
+MTU=1500
+NM_CONTROLLED=yes
+ONBOOT=yes
+{% if 'ip' in item %}
+IPADDR={{ item.ip }}
+{% endif %}
+{% if 'netmask' in item %}
+NETMASK={{ item.netmask }}
+{% endif %}
+{% if 'type' in item %}
+TYPE={{ item.type }}
+{% else %}
+TYPE=Ethernet
+{% endif %}
+{% if 'hwaddr' in item %}
+HWADDR={{ item.hwaddr }}
+{% endif %}
+{% if 'gateway' in item %}
+GATEWAY={{ item.gateway }}
+{% endif %}
+{% if 'dns1' in item %}
+DNS1={{ item.dns1 }}
+{% endif %}
+{% if 'dns2' in item %}
+DNS2={{ item.dns2 }}
+{% endif %}
+{% if 'bridge' in item %}
+BRIDGE={{ item.bridge }}
+{% endif %}
+USERCTL=no

--- a/ansible/roles/samba-client/README.md
+++ b/ansible/roles/samba-client/README.md
@@ -1,0 +1,9 @@
+Samba Client
+============
+
+Install packages for accessing samba shares.
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/samba-client/tasks/main.yml
+++ b/ansible/roles/samba-client/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# Install Samba client packages for mounts
+
+- name: samba mounts | install clients
+  yum:
+    pkg: "{{ item }}"
+    state: latest
+  with_items:
+    - samba-client
+    - cifs-utils


### PR DESCRIPTION
Includes
- docker-storage for setting up the docker thin partitions
- docker for setting up docker including groups
- lvm-partition as a generic role for creating any LVM storage partition
- role for installing samba-clients

Also separate playbooks for provisioning (setting up hardware) and deploying (everything else which doesn't involve hardware configuration)

Note the generic `lvm-partition` role could be used to replace the `jenkinsslave-storage` role in a future PR.