### PR TITLE
Install git on IDR nodes

### DIFF
--- a/ansible/idr-deployment.yml
+++ b/ansible/idr-deployment.yml
@@ -7,3 +7,4 @@
   - role: docker-dns-server
   - role: docker-dns-client
   - role: samba-client
+  - role: versioncontrol-utils

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: system packages | install docker
   yum:
     pkg: "{{ item }}"
-    state: latest
+    state: present
     enablerepo: extras
   with_items:
     - docker

--- a/ansible/roles/omero-basedeps/tasks/main.yml
+++ b/ansible/roles/omero-basedeps/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
-# tasks file for roles/omero-build-base
+# tasks file for roles/omero-basedeps
 
 - name: system packages | install epel repo
   yum:
     name: epel-release
     state: latest
 
-- name: system packages | basic build deps
+- name: system packages | basic system utils
   yum:
     name: "{{ item }}"
     state: latest

--- a/ansible/roles/samba-client/tasks/main.yml
+++ b/ansible/roles/samba-client/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: samba mounts | install clients
   yum:
     pkg: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - samba-client
     - cifs-utils

--- a/ansible/roles/versioncontrol-utils/README.md
+++ b/ansible/roles/versioncontrol-utils/README.md
@@ -1,0 +1,9 @@
+Version control utilities
+=========================
+
+Utilities for managing source code.
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/versioncontrol-utils/tasks/main.yml
+++ b/ansible/roles/versioncontrol-utils/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# tasks file for roles/versioncontrol-utils
+
+- name: system packages | install epel repo
+  yum:
+    name: epel-release
+    state: latest
+
+- name: system packages | basic system utils
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - git

--- a/ansible/roles/versioncontrol-utils/tasks/main.yml
+++ b/ansible/roles/versioncontrol-utils/tasks/main.yml
@@ -9,6 +9,6 @@
 - name: system packages | basic system utils
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - git


### PR DESCRIPTION
Add `versioncontrol-utils` role for servers which need to manage code but are not full development/build servers. Also changed `yum state` from `latest` to `present` to avoid upgrading some packages such as docker without warning. If there's no objections I'll do the same for all other roles in a future PR.

Tested with `idr-deployment.yml` (i.e. I ran the playbook and applied the changes).