### PR TITLE
Add role for creating nginx self-signed certificates

### DIFF
--- a/ansible/roles/nginx-ssl-selfsigned/README.md
+++ b/ansible/roles/nginx-ssl-selfsigned/README.md
@@ -1,0 +1,27 @@
+Nginx SSL Self-Signed
+=====================
+
+Generate self-signed SSL certificates for Nginx, for internal testing.
+
+Role Variables
+--------------
+
+Defaults: `defaults/main.yml`
+
+Optional variables:
+
+- `nginx_ssl_certificate_subject`: Certificate subject
+- `nginx_ssl_certificate_days`: Certificate validity, default 365 days
+- `nginx_ssl_certificate`: Server path to SSL certificate
+- `nginx_ssl_certificate_key`: Server path to SSL certificate key
+
+Note this role does not configure Nginx for SSL, nor does it restart Nginx.
+This should be handled elsewhere.
+System variables:
+
+- `runningindocker`: systemd doesn't currently work inside Docker without some fiddling. Set this variable to `True` to start nginx directly, default `False`.
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/nginx-ssl-selfsigned/README.md
+++ b/ansible/roles/nginx-ssl-selfsigned/README.md
@@ -17,9 +17,7 @@ Optional variables:
 
 Note this role does not configure Nginx for SSL, nor does it restart Nginx.
 This should be handled elsewhere.
-System variables:
 
-- `runningindocker`: systemd doesn't currently work inside Docker without some fiddling. Set this variable to `True` to start nginx directly, default `False`.
 
 Author Information
 ------------------

--- a/ansible/roles/nginx-ssl-selfsigned/defaults/main.yml
+++ b/ansible/roles/nginx-ssl-selfsigned/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# defaults file for roles/nginx-ssl-selfsigned
+
+# Certificate subject
+nginx_ssl_certificate_subject: "/C=UK/ST=Scotland/L=Dundee/O=OME/CN={{ ansible_fqdn }}"
+
+# Certificate validity (days)
+nginx_ssl_certificate_days: 365
+
+# Server path to SSL certificate
+nginx_ssl_certificate: /etc/nginx/ssl/server.crt
+
+# Server path to SSL certificate key
+nginx_ssl_certificate_key: /etc/nginx/ssl/server.key
+
+# Systemd doesn't work inside Docker
+runningindocker: False

--- a/ansible/roles/nginx-ssl-selfsigned/tasks/main.yml
+++ b/ansible/roles/nginx-ssl-selfsigned/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# tasks file for roles/nginx-ssl-selfsigned
+
+- name: system packages | install openssl
+  yum:
+    name: openssl
+    state: latest
+
+- name: nginx | create certificates directory
+  file:
+    path: "{{ item | dirname }}"
+    state: directory
+  with_items:
+    - "{{ nginx_ssl_certificate }}"
+    - "{{ nginx_ssl_certificate_key }}"
+
+# http://serialized.net/2013/04/simply-generating-self-signed-ssl-certs-with-ansible/
+- name: nginx | generate self-signed SSL certificate
+  command:
+    openssl req -new -nodes -x509 -subj "{{ nginx_ssl_certificate_subject }}" -days {{ nginx_ssl_certificate_days }} -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -extensions v3_ca
+  args:
+    creates: "{{ nginx_ssl_certificate }}"


### PR DESCRIPTION
This is useful for testing https internally.