### PR TITLE
systemctl daemon-reload, other docker fixes

### DIFF
--- a/ansible/ci-provision.yml
+++ b/ansible/ci-provision.yml
@@ -11,7 +11,7 @@
 
 # Playbook for provisioning Docker Production nodes
 
-- hosts: prod-docker-internal
+- hosts: docker-prod-hosts
   roles:
   - role: lvm-partition
     lvm_lvname: root

--- a/ansible/idr-deployment.yml
+++ b/ansible/idr-deployment.yml
@@ -1,9 +1,12 @@
 ---
 # Playbook for maintaining IDR Docker nodes
 
-- hosts: idr-docker,idr-docker-localstorage
+- hosts: idr-docker
   roles:
   - role: docker-advanced
+
+- hosts: idr-docker,idr-docker-localstorage
+  roles:
   - role: docker-dns-server
   - role: docker-dns-client
   - role: samba-client

--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -3,6 +3,7 @@
 
 - hosts: idr-docker
   roles:
+  - role: server-swap
   - role: network
   - role: docker-storage
   - role: lvm-partition
@@ -16,6 +17,8 @@
 
 - hosts: idr-docker-localstorage
   roles:
+  - role: upgrade-distpackages
+  - role: server-swap
   - role: network
   - role: lvm-partition
     lvm_lvname: root
@@ -28,5 +31,4 @@
     lvm_lvsize: "{{ scratch_size }}"
     lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: basedeps
-  - role: upgrade-distpackages
   - role: docker

--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -16,9 +16,7 @@
 
 - hosts: idr-docker-localstorage
   roles:
-  - role: upgrade-distpackages
   - role: network
-  - role: docker-storage
   - role: lvm-partition
     lvm_lvname: root
     lvm_lvmount: /
@@ -27,4 +25,8 @@
   - role: lvm-partition
     lvm_lvname: scratch
     lvm_lvmount: /scratch
-    lvm_lvsize: "{{ scratchsize }}"
+    lvm_lvsize: "{{ scratch_size }}"
+    lvm_lvfilesystem: "{{ scratch_filesystem }}"
+  - role: basedeps
+  - role: upgrade-distpackages
+  - role: docker

--- a/ansible/roles/docker-dns-client/templates/systemd-docker-registrator.j2
+++ b/ansible/roles/docker-dns-client/templates/systemd-docker-registrator.j2
@@ -13,11 +13,14 @@ ExecStartPre=-/usr/bin/docker rm registrator
 ExecStart=/usr/bin/docker run --name registrator \
     --link {{ docker_dns.etcd }}:etcd \
     -v /var/run/docker.sock:/tmp/docker.sock \
-    manics/registrator \
+    --entrypoint=sh \
+    manics/registrator -c \
+    "sleep 5; \
+     registrator \
     -iponly \
     -ttl 60 \
     -ttl-refresh=30 \
-    skydns2://etcd:2379/{{ docker_dns.domain }}
+    skydns2://etcd:2379/{{ docker_dns.domain }}"
 ExecStop=/usr/bin/docker stop registrator
 
 [Install]

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -10,3 +10,6 @@ docker_use_custom_storage: False
 
 # Set to True if using a custom network configuration
 docker_use_custom_network: False
+
+# Any other arguments to be passed to the docker daemon
+docker_additional_args:

--- a/ansible/roles/docker/tasks/advanced-upstream.yml
+++ b/ansible/roles/docker/tasks/advanced-upstream.yml
@@ -6,7 +6,7 @@
     src: docker-engine.j2
     dest: /etc/sysconfig/docker-engine
     backup: yes
-  when: docker_use_custom_storage or docker_use_custom_network
+  when: docker_use_custom_storage or docker_use_custom_network or docker_additional_args
   notify:
     - restart docker
 

--- a/ansible/roles/docker/tasks/advanced-upstream.yml
+++ b/ansible/roles/docker/tasks/advanced-upstream.yml
@@ -13,19 +13,28 @@
 # Upstream docker doesn't automatically load custom settings, so we need to
 # customise the systemd file
 
-- name: Check change-time of original docker.service
+- name: upstream docker| check change-time of original docker.service
   stat:
     path: /usr/lib/systemd/system/docker.service
   register: st0
 
-- name: Check change-time of modified docker.service
+- name: upstream docker| check change-time of modified docker.service
   stat:
     path: /etc/systemd/system/docker.service
   register: st1
 
+- name: upstream docker | check docker.service systemd file update required
+  set_fact:
+    docker_systemd_file_update: (docker_use_custom_storage or docker_use_custom_network) and (not st1.stat.exists or st1.stat.ctime < st0.stat.ctime)
+
 - name: upstream docker | copy systemd file
   command: cp /usr/lib/systemd/system/docker.service /etc/systemd/system/docker.service
-  when: (docker_use_custom_storage or docker_use_custom_network) and (not st1.stat.exists or st1.stat.ctime < st0.stat.ctime)
+  when: docker_systemd_file_update
+
+# Can't use a notifier because the reload must happen before a start/restart
+- name: docker production | reload systemd
+  command: systemctl daemon-reload
+  when: docker_systemd_file_update
   notify:
     - restart docker
 

--- a/ansible/roles/docker/tasks/docker-centos.yml
+++ b/ansible/roles/docker/tasks/docker-centos.yml
@@ -15,11 +15,11 @@
     state: present
     system: yes
 
-- name: docker | set group for docker socket
+- name: docker | set additional docker options
   replace:
     backup: yes
     dest: /etc/sysconfig/docker
     regexp: ^\s*OPTIONS='--selinux-enabled'\s*$
-    replace: OPTIONS='--selinux-enabled -G docker'
+    replace: OPTIONS='--selinux-enabled -G docker {{ docker_additional_args }}'
   notify:
     - restart docker

--- a/ansible/roles/docker/templates/docker-engine.j2
+++ b/ansible/roles/docker/templates/docker-engine.j2
@@ -9,4 +9,5 @@ DOCKER_OPTIONS="\
     -b {{ docker_bridge_name }} \
     --fixed-cidr {{ docker_bridge_ips }} \
 {% endif %}
+    {{ docker_additional_args }} \
     "

--- a/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -10,6 +10,9 @@ IPADDR={{ item.ip }}
 {% if 'netmask' in item %}
 NETMASK={{ item.netmask }}
 {% endif %}
+{% if 'prefix' in item %}
+PREFIX={{ item.prefix }}
+{% endif %}
 {% if 'type' in item %}
 TYPE={{ item.type }}
 {% else %}

--- a/ansible/roles/server-swap/README.md
+++ b/ansible/roles/server-swap/README.md
@@ -1,0 +1,18 @@
+Server Swap
+===========
+
+Configure swap for a server.
+
+TODO: This is a work in progress.
+
+
+Role Variables
+--------------
+
+`sysctl_vm_swappiness`: vm.swappiness
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/server-swap/defaults/main.yml
+++ b/ansible/roles/server-swap/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for roles/server-swap
+
+sysctl_vm_swappiness: 1

--- a/ansible/roles/server-swap/tasks/main.yml
+++ b/ansible/roles/server-swap/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for roles/server-swap
+
+- name: sysctl | set vm swappiness
+  sysctl:
+    ignoreerrors: no
+    reload: yes
+    state: present
+    name: vm.swappiness
+    value: "{{ sysctl_vm_swappiness }}"


### PR DESCRIPTION
- Fixes an error found in #32 when using the non-default storage config.

Rebased and updated: 2015-12-10:
- Allows additional parameters to be passed to the docker daemon, for example to work around strange incompatibilities between systemd/cgroups/docker which may occur when using the upstream version. E.g https://github.com/docker/docker/issues/16256 (though the bug observed is different)
- Adds workaround for registrator sometimes failing to start

Update 2015-12-11
- Include #40 Attempt to reduce swap load http://serverfault.com/a/692515