### PR TITLE
Ansible tasks: state: present, become: yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,22 +65,21 @@ In the following examples replace example-hosts with the private host inventory 
 
 Dry-run `ci-provision.yml` for all hosts listed in `ci-provision.yml`:
 - `-u` Login as this user
-- `-b` use `sudo`
 - `--ask-become-pass` prompt for sudo password
 - `-C` Dry-run mode
 - `-v` Verbose (repeat to increase verbosity)
 
 Note this may fail since some tasks are dependent on others being completed:
 
-    ansible-playbook -i example-hosts -u $USERNAME -b --ask-become-pass -C -v ci-provision.yml
+    ansible-playbook -i example-hosts -u $USERNAME --ask-become-pass -C -v ci-provision.yml
 
 Run `provision.yml`:
 
-    ansible-playbook -i example-hosts -u $USERNAME -b --ask-become-pass ci-provision.yml
+    ansible-playbook -i example-hosts -u $USERNAME --ask-become-pass ci-provision.yml
 
 Run `provision.yml` for all subset of the hosts or groups listed in `provision.yml`:
 
-    ansible-playbook -i example-hosts -u $USERNAME -b --ask-become-pass ci-provision.yml --limit $HOST_OR_GROUP_NAME
+    ansible-playbook -i example-hosts -u $USERNAME --ask-become-pass ci-provision.yml --limit $HOST_OR_GROUP_NAME
 
 List the hosts that would be targeted by a command, don't do anything else:
 

--- a/ansible/roles/basedeps/tasks/main.yml
+++ b/ansible/roles/basedeps/tasks/main.yml
@@ -2,14 +2,16 @@
 # tasks file for roles/basedeps
 
 - name: system packages | install epel repo
+  become: yes
   yum:
     name: epel-release
-    state: latest
+    state: present
 
 - name: system packages | basic system utils
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - patch
     - redhat-lsb-core

--- a/ansible/roles/docker-advanced/tasks/main.yml
+++ b/ansible/roles/docker-advanced/tasks/main.yml
@@ -2,6 +2,7 @@
 # Setup a Docker node
 
 - name: system packages | install docker
+  become: yes
   yum:
     pkg: "{{ item }}"
     state: present
@@ -10,6 +11,7 @@
     - docker
 
 - name: docker | disable storage autoconfiguration
+  become: yes
   copy:
     src: docker-storage-setup
     dest: /etc/sysconfig/docker-storage-setup
@@ -18,6 +20,7 @@
     - restart docker
 
 - name: docker | configure storage
+  become: yes
   template:
     src: docker-storage.j2
     dest: /etc/sysconfig/docker-storage
@@ -26,6 +29,7 @@
     - restart docker
 
 - name: docker | configure network
+  become: yes
   template:
     src: docker-network.j2
     dest: /etc/sysconfig/docker-network
@@ -37,12 +41,14 @@
 # In recent versions of CentOS7 Docker the docker group isn't created
 
 - name: docker | create docker group
+  become: yes
   group:
     name: docker
     state: present
     system: yes
 
 - name: docker | set group for docker socket
+  become: yes
   replace:
     backup: yes
     dest: /etc/sysconfig/docker
@@ -52,12 +58,14 @@
     - restart docker
 
 - name: docker | enable
+  become: yes
   service:
     name: docker
     state: started
     enabled: yes
 
 - name: docker | group members
+  become: yes
   user:
     name: "{{ item }}"
     groups: docker

--- a/ansible/roles/docker-dns-client/tasks/main.yml
+++ b/ansible/roles/docker-dns-client/tasks/main.yml
@@ -2,6 +2,7 @@
 # Setup production Docker DNS clients to run automatically
 
 - name: docker production | registrator
+  become: yes
   template:
     src: systemd-docker-registrator.j2
     dest: /etc/systemd/system/docker-registrator.service
@@ -10,10 +11,12 @@
 # Can't use a notifier because the reload must happen before the next step
 
 - name: reload systemd
+  become: yes
   command: systemctl daemon-reload
   when: systemdregistrator.changed
 
 - name: docker production | enable registrator
+  become: yes
   service:
     enabled: yes
     name: docker-registrator.service
@@ -22,5 +25,6 @@
 # service module doesn't seem to work for a new systemd.service
 
 - name: docker production | enable registrator
+  become: yes
   command: systemctl restart docker-registrator.service
   when: systemdregistrator.changed

--- a/ansible/roles/docker-dns-server/tasks/main.yml
+++ b/ansible/roles/docker-dns-server/tasks/main.yml
@@ -2,12 +2,14 @@
 # Setup production Docker services to run automatically
 
 - name: docker production | etcd
+  become: yes
   template:
     src: systemd-docker-etcd.j2
     dest: /etc/systemd/system/docker-{{ docker_dns.etcd }}.service
   register: systemdetcd
 
 - name: docker production | skydns
+  become: yes
   template:
     src: systemd-docker-skydns.j2
     dest: /etc/systemd/system/docker-skydns.service
@@ -16,16 +18,19 @@
 # Can't use a notifier because the reload must happen before the next step
 
 - name: docker production | reload systemd
+  become: yes
   command: systemctl daemon-reload
   when: systemdetcd.changed or systemdskydns.changed
 
 - name: docker production | enable etcd
+  become: yes
   service:
     enabled: yes
     name: docker-{{ docker_dns.etcd }}.service
     state: started
 
 - name: docker production | enable skydns
+  become: yes
   service:
     enabled: yes
     name: docker-skydns.service
@@ -36,9 +41,11 @@
 # TODO: check if it works in the latest version
 
 - name: docker production | restart etcd
+  become: yes
   command: systemctl restart docker-{{ docker_dns.etcd }}.service
   when: systemdetcd.changed
 
 - name: docker production | restart skydns
+  become: yes
   command: systemctl restart docker-skydns.service
   when: systemdskydns.changed

--- a/ansible/roles/docker-storage/tasks/main.yml
+++ b/ansible/roles/docker-storage/tasks/main.yml
@@ -2,6 +2,7 @@
 # Setup LVM partitions for Docker
 
 - name: storage | setup lvm docker-pool
+  become: yes
   lvol:
     vg: "{{ docker_vgname }}"
     lv: docker-pool

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -2,7 +2,9 @@
 # Handlers for docker
 
 - name: run docker-storage-setup
+  become: yes
   service: name=docker-storage-setup state=restarted
 
 - name: restart docker
+  become: yes
   service: name=docker state=restarted

--- a/ansible/roles/docker/tasks/advanced-centos.yml
+++ b/ansible/roles/docker/tasks/advanced-centos.yml
@@ -2,6 +2,7 @@
 # Advanced configuration for Docker
 
 - name: docker | disable storage autoconfiguration
+  become: yes
   copy:
     src: docker-storage-setup
     dest: /etc/sysconfig/docker-storage-setup
@@ -11,6 +12,7 @@
     - restart docker
 
 - name: docker | configure storage
+  become: yes
   template:
     src: docker-storage.j2
     dest: /etc/sysconfig/docker-storage
@@ -20,6 +22,7 @@
     - restart docker
 
 - name: docker | configure network
+  become: yes
   template:
     src: docker-network.j2
     dest: /etc/sysconfig/docker-network

--- a/ansible/roles/docker/tasks/advanced-common.yml
+++ b/ansible/roles/docker/tasks/advanced-common.yml
@@ -2,6 +2,7 @@
 # Advanced configuration for Docker
 
 - name: storage | setup lvm docker-pool
+  become: yes
   lvol:
     vg: "{{ docker_vgname }}"
     lv: docker-pool

--- a/ansible/roles/docker/tasks/advanced-upstream.yml
+++ b/ansible/roles/docker/tasks/advanced-upstream.yml
@@ -2,6 +2,7 @@
 # Advanced configuration for Docker
 
 - name: upstream docker | configure advanced
+  become: yes
   template:
     src: docker-engine.j2
     dest: /etc/sysconfig/docker-engine
@@ -28,11 +29,13 @@
     docker_systemd_file_update: (docker_use_custom_storage or docker_use_custom_network) and (not st1.stat.exists or st1.stat.ctime < st0.stat.ctime)
 
 - name: upstream docker | copy systemd file
+  become: yes
   command: cp /usr/lib/systemd/system/docker.service /etc/systemd/system/docker.service
   when: docker_systemd_file_update
 
 # Can't use a notifier because the reload must happen before a start/restart
 - name: docker production | reload systemd
+  become: yes
   command: systemctl daemon-reload
   when: docker_systemd_file_update
   notify:
@@ -40,6 +43,7 @@
 
 # Use patch so that we know if upstream makes any significant changes
 - name: upstream docker | customise systemd file
+  become: yes
   patch:
     dest: /etc/systemd/system/docker.service
     src: docker-service.patch
@@ -48,6 +52,7 @@
     - restart docker
 
 - name: upstream docker | remove custom systemd file
+  become: yes
   file:
     path: /etc/systemd/system/docker.service
     state: absent

--- a/ansible/roles/docker/tasks/docker-centos.yml
+++ b/ansible/roles/docker/tasks/docker-centos.yml
@@ -2,6 +2,7 @@
 # Distribution (Centos 7) docker
 
 - name: system packages | install docker
+  become: yes
   yum:
     pkg: docker
     state: present
@@ -10,12 +11,14 @@
 # In recent versions of Centos 7 Docker the docker group isn't created
 
 - name: docker | create docker group
+  become: yes
   group:
     name: docker
     state: present
     system: yes
 
 - name: docker | set additional docker options
+  become: yes
   replace:
     backup: yes
     dest: /etc/sysconfig/docker

--- a/ansible/roles/docker/tasks/docker-common.yml
+++ b/ansible/roles/docker/tasks/docker-common.yml
@@ -2,12 +2,14 @@
 # Setup a Docker node
 
 - name: docker | enable
+  become: yes
   service:
     name: docker
     state: started
     enabled: yes
 
 - name: docker | group members
+  become: yes
   user:
     name: "{{ item }}"
     groups: docker

--- a/ansible/roles/docker/tasks/docker-upstream.yml
+++ b/ansible/roles/docker/tasks/docker-upstream.yml
@@ -2,12 +2,14 @@
 # Upstream Docker
 
 - name: upstream docker | setup repository
+  become: yes
   copy:
     src: docker.repo
     dest: /etc/yum.repos.d/
     backup: no
 
 - name: upstream docker | install docker
+  become: yes
   yum:
     pkg: docker-engine
     state: present

--- a/ansible/roles/ice/tasks/main.yml
+++ b/ansible/roles/ice/tasks/main.yml
@@ -5,30 +5,35 @@
   include_vars: ice-{{ ice_version }}.yml
 
 - name: zeroc ice | setup repository
+  become: yes
   get_url:
     dest: /etc/yum.repos.d/zeroc-ice-el7.repo
     url: "{{ ice_repourl }}"
 
 - name: zeroc ice | install runtime packages
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items: "{{ ice_runtime_packages }}"
 
 - name: zeroc ice | install devel packages
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items: "{{ ice_devel_packages }}"
 
 - name: zeroc ice | install ice pip dependencies
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items: "{{ ice_pip_dependencies }}"
   when: ice_pip_dependencies
 
 - name: zeroc ice | pip install packages
+  become: yes
   pip:
     name: "{{ item.name }}"
     state: present

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -2,15 +2,17 @@
 # tasks file for roles/java
 
 - name: system packages | install java jre
+  become: yes
   yum:
     name: "java-{{ item }}-openjdk"
-    state: latest
+    state: present
   with_items: javajreversions
   when: javajreversions.0 is defined
 
 - name: system packages | install java jdk
+  become: yes
   yum:
     name: "java-{{ item }}-openjdk-devel"
-    state: latest
+    state: present
   with_items: javajdkversions
   when: javajdkversions.0 is defined

--- a/ansible/roles/jenkinsslave/tasks/main.yml
+++ b/ansible/roles/jenkinsslave/tasks/main.yml
@@ -2,11 +2,13 @@
 # Setup a Jenkins-CI slave
 
 - name: jenkins | create user
+  become: yes
   user:
     name: "{{ jenkinsuser }}"
     append: yes
 
 - name: jenkins | jenkins workspace
+  become: yes
   file:
     path: "{{ jenkinsworkdir }}"
     state: directory
@@ -14,11 +16,13 @@
     group: "{{ jenkinsuser }}"
 
 - name: jenkins | ssh key
+  become: yes
   authorized_key:
     user: "{{ jenkinsuser }}"
     key: "{{ authorized_key }}"
 
 - name: jenkins | ssh access
+  become: yes
   lineinfile:
     dest: /etc/security/access.conf
     backup: yes
@@ -27,6 +31,7 @@
   when: not spacewalk
 
 - name: jenkins | git config
+  become: yes
   template:
     src: gitconfig.j2
     dest: /home/{{ jenkinsuser }}/.gitconfig

--- a/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
+++ b/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
@@ -10,6 +10,8 @@
     - python-virtualenv
     
 - name: virtualenv | scc
+  become: yes
+  become_user: "{{ jenkinsuser }}"
   pip:
     virtualenv: /home/{{ jenkinsuser }}/virtualenv
     name: scc

--- a/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
+++ b/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
@@ -1,9 +1,10 @@
 ---
 
 - name: virtualenv | install python tools
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - python-pip
     - python-virtualenv

--- a/ansible/roles/lvm-partition/tasks/main.yml
+++ b/ansible/roles/lvm-partition/tasks/main.yml
@@ -2,6 +2,7 @@
 # Setup LVM partition
 
 - name: storage | create logical volume
+  become: yes
   lvol:
     vg: "{{ lvm_vgname }}"
     lv: "{{ lvm_lvname }}"
@@ -9,12 +10,14 @@
     opts: "{{ lvm_lvopts | default(None) }}"
 
 - name: storage | format
+  become: yes
   filesystem:
     fstype: "{{ lvm_lvfilesystem }}"
     dev: /dev/{{ lvm_vgname }}/{{ lvm_lvname }}
     resizefs: yes
 
 - name: storage | mount
+  become: yes
   mount:
     name: "{{ lvm_lvmount }}"
     src: /dev/{{ lvm_vgname }}/{{ lvm_lvname }}

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -2,6 +2,7 @@
 # Setup network interfaces
 
 - name: network | Setup nics
+  become: yes
   template: src=etc-sysconfig-network-scripts-ifcfg.j2 dest=/etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
   with_items: networkifaces
   notify:

--- a/ansible/roles/nginx-proxy/tasks/main.yml
+++ b/ansible/roles/nginx-proxy/tasks/main.yml
@@ -2,16 +2,19 @@
 # tasks file for roles/nginx-proxy
 
 - name: system packages | setup upstream nginx repo
+  become: yes
   yum:
     name: http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm
     state: present
 
 - name: system packages | install nginx
+  become: yes
   yum:
     name: nginx
-    state: latest
+    state: presentt
 
 - name: nginx | remove default config
+  become: yes
   file:
     dest: /etc/nginx/conf.d/{{ item }}
     state: absent
@@ -22,6 +25,7 @@
     - restart nginx
 
 - name: nginx | main config
+  become: yes
   template:
     src: nginx-conf.j2
     dest: /etc/nginx/nginx.conf
@@ -29,6 +33,7 @@
     - restart nginx
 
 - name: nginx | dynamic proxy config
+  become: yes
   template:
     src: nginx-confd-dynamic-proxy.j2
     dest: /etc/nginx/conf.d/dynamic-proxy.conf
@@ -37,6 +42,7 @@
   when: nginx_dynamic_proxies is defined and nginx_dynamic_proxies
 
 - name: nginx | dynamic proxy remove config
+  become: yes
   file:
     dest: /etc/nginx/conf.d/dynamic-proxy.conf
     state: absent
@@ -45,6 +51,7 @@
   when: nginx_dynamic_proxies is not defined or not nginx_dynamic_proxies
 
 - name: nginx | start service
+  become: yes
   service:
     enabled: yes
     name: nginx
@@ -53,6 +60,7 @@
 
 # Command copied from /usr/lib/systemd/system/nginx.service
 - name: nginx | start service
+  become: yes
   command: /usr/sbin/nginx -c /etc/nginx/nginx.conf
   args:
     # Only run command if nginx.pid doesn't exist

--- a/ansible/roles/nginx-ssl-selfsigned/tasks/main.yml
+++ b/ansible/roles/nginx-ssl-selfsigned/tasks/main.yml
@@ -2,11 +2,13 @@
 # tasks file for roles/nginx-ssl-selfsigned
 
 - name: system packages | install openssl
+  become: yes
   yum:
     name: openssl
-    state: latest
+    state: present
 
 - name: nginx | create certificates directory
+  become: yes
   file:
     path: "{{ item | dirname }}"
     state: directory
@@ -16,6 +18,7 @@
 
 # http://serialized.net/2013/04/simply-generating-self-signed-ssl-certs-with-ansible/
 - name: nginx | generate self-signed SSL certificate
+  become: yes
   command:
     openssl req -new -nodes -x509 -subj "{{ nginx_ssl_certificate_subject }}" -days {{ nginx_ssl_certificate_days }} -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -extensions v3_ca
   args:

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for roles/nginx
 
 - name: system packages | install nginx
+  become: yes
   yum:
     name: nginx
-    state: latest
+    state: present

--- a/ansible/roles/omero-build-cpp/tasks/main.yml
+++ b/ansible/roles/omero-build-cpp/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for roles/omero-build-cpp
 
 - name: system packages | install C++ build tools
+  become: yes
   yum:
     name: "@Development Tools"
-    state: latest
+    state: present

--- a/ansible/roles/omero-build/tasks/main.yml
+++ b/ansible/roles/omero-build/tasks/main.yml
@@ -2,9 +2,10 @@
 # tasks file for roles/omero-build
 
 - name: system packages | install build tools
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - ant
     - ant-contrib
@@ -15,9 +16,10 @@
     - maven
 
 - name: system packages | install build libraries
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - boost-devel
     - libjpeg-turbo-devel
@@ -27,18 +29,20 @@
     - zlib-devel
 
 - name: system packages | install python tools
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - python-devel
     - python-pip
     - python-virtualenv
 
 - name: system packages | install epel packages
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
     enablerepo: epel
   with_items:
     - hdf5-devel
@@ -48,6 +52,7 @@
 # so use `creates` in `unarchive`
 
 - name: cmake | download and extract
+  become: yes
   unarchive:
     copy: no
     creates: /opt/cmake-3.3.2-Linux-x86_64/bin/cmake
@@ -55,6 +60,7 @@
     src: http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz
 
 - name: cmake | symlink
+  become: yes
   file:
     force: yes
     path: /opt/cmake
@@ -62,6 +68,7 @@
     state: link
 
 - name: cmake | set the global path to include cmake bin
+  become: yes
   template:
     src: cmake-path.sh.j2
     dest: "/etc/profile.d/cmake-path.sh"
@@ -71,11 +78,13 @@
     mode: 0644
 
 - name: exe4j packages | install
+  become: yes
   yum:
     name: http://download-aws.ej-technologies.com/exe4j/exe4j_linux_5_0_1.rpm
     state: present
 
 - name: findbugs | download and extract
+  become: yes
   unarchive:
     copy: no
     creates: /opt/findbugs-3.0.1/bin/findbugs
@@ -83,6 +92,7 @@
     src: http://prdownloads.sourceforge.net/findbugs/findbugs-3.0.1.tar.gz?download
 
 - name: findbugs | symlink
+  become: yes
   file:
     force: yes
     path: /opt/findbugs
@@ -90,11 +100,13 @@
     state: link
 
 - name: ninja | create parent dir
+  become: yes
   file:
     path: /opt/ninja-1.6.0
     state: directory
 
 - name: ninja | download and extract
+  become: yes
   unarchive:
     copy: no
     # Ansible doesn't detect when this already exists, so use creates:
@@ -103,6 +115,7 @@
     src: https://github.com/martine/ninja/releases/download/v1.6.0/ninja-linux.zip
 
 - name: ninja | symlink
+  become: yes
   file:
     force: yes
     path: /opt/ninja

--- a/ansible/roles/omero-runtime/tasks/main.yml
+++ b/ansible/roles/omero-runtime/tasks/main.yml
@@ -2,9 +2,10 @@
 # tasks file for roles/omero-runtime
 
 - name: system packages | install python tools
+  become: yes
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     - Cython
     - numpy

--- a/ansible/roles/openldap-devel/tasks/main.yml
+++ b/ansible/roles/openldap-devel/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for roles/openldap-devel
 
 - name: install openldap-devel
+  become: yes
   yum:
     name: "{{ item }}"
     state: present

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -2,23 +2,27 @@
 # tasks file for roles/postgres
 
 - name: postgres | setup repository
+  become: yes
   yum:
     name: "{{ postgresqlrepourl }}"
     state: present
 
 - name: postgres | install client packages
+  become: yes
   yum:
     name: "{{ postgresqlbasename }}"
-    state: latest
+    state: present
 
 - name: postgres | install additional packages
+  become: yes
   yum:
     name: "{{ postgresqlbasename }}-{{ item }}"
-    state: latest
+    state: present
   with_items: postgressubpackages
   when: postgressubpackages.0 is defined
 
 - name: postgres | initialise data directory
+  become: yes
   command: "{{ postgresqlbindir }}/{{ postgresqlbasename }}-setup initdb"
   args:
     creates: "{{ postgresqldatadir }}/PG_VERSION"
@@ -27,6 +31,7 @@
   when: not runningindocker
 
 - name: postgres | initialise data directory
+  become: yes
   command: "{{ postgresqlbindir }}/initdb --pgdata={{ postgresqldatadir }} --encoding=UTF8 --locale=en_US.UTF-8 --auth-host=md5"
   args:
     creates: "{{ postgresqldatadir }}/PG_VERSION"
@@ -34,6 +39,7 @@
   when: runningindocker
 
 - name: postgres | start service
+  become: yes
   service:
     enabled: yes
     name: postgresql-{{ postgresversion }}
@@ -42,6 +48,7 @@
 
 # Command copied from /usr/lib/systemd/system/postgresql-9.4.service
 - name: postgres | start service
+  become: yes
   command: "{{ postgresqlbindir }}/pg_ctl start -D {{ postgresqldatadir }} -s -w -t 300"
   args:
     # Only run command if postmaster.pid doesn't exist

--- a/ansible/roles/python-devel/tasks/main.yml
+++ b/ansible/roles/python-devel/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for roles/python-devel
 
 - name: install python-devel
+  become: yes
   yum:
     name: "{{ item }}"
     state: present

--- a/ansible/roles/samba-client/tasks/main.yml
+++ b/ansible/roles/samba-client/tasks/main.yml
@@ -2,6 +2,7 @@
 # Install Samba client packages for mounts
 
 - name: samba mounts | install clients
+  become: yes
   yum:
     pkg: "{{ item }}"
     state: present

--- a/ansible/roles/server-swap/tasks/main.yml
+++ b/ansible/roles/server-swap/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for roles/server-swap
 
 - name: sysctl | set vm swappiness
+  become: yes
   sysctl:
     ignoreerrors: no
     reload: yes

--- a/ansible/roles/system-monitor-agent/tasks/main.yml
+++ b/ansible/roles/system-monitor-agent/tasks/main.yml
@@ -2,11 +2,13 @@
 # tasks file for roles/system-monitor-agent
 
 - name: system packages | install epel repo
+  become: yes
   yum:
     name: epel-release
-    state: latest
+    state: present
 
 - name: system packages | check-mk agent
+  become: yes
   yum:
     name: "{{ item }}"
     state: present
@@ -15,6 +17,7 @@
     - xinetd
 
 - name: xinetd | start and enable
+  become: yes
   service:
     enabled: yes
     name: xinetd.service

--- a/ansible/roles/texlive/tasks/main.yml
+++ b/ansible/roles/texlive/tasks/main.yml
@@ -1,16 +1,21 @@
 - name: texlive | prereq
-  yum: name={{ item }} state=latest
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
     - perl-Tk
     - perl-Digest-MD5
     - wget
 
 - name: texlive | check for texlive_TEXDIR path existence
+  become: yes
   stat: 
     path: "{{ texlive_TEXDIR }}"
   register: texdir_path
 
 - name: texlive | create the temp install folder
+  become: yes
   file: 
     path: "{{ texlive_dest }}/tmp/" 
     state: directory 
@@ -19,6 +24,7 @@
   when: texdir_path.stat.exists == false
     
 - name: texlive | download and extract installer
+  become: yes
   unarchive:
     copy: no
     # Checking whether this version of texlive has been
@@ -28,6 +34,7 @@
     src: http://mirror.unl.edu/ctan/systems/texlive/tlnet/install-tl-unx.tar.gz
 
 - name: texlive | rename the installer folder
+  become: yes
   shell: mv install-tl-* install-tl-ansible
   args:
     chdir: "{{ texlive_dest }}/tmp/"
@@ -36,6 +43,7 @@
   when: texdir_path.stat.exists == false
 
 - name: texlive | copy out the templated install-tl.profile
+  become: yes
   template: 
     src: install-tl.profile.j2
     dest: "{{ texlive_dest }}/tmp/install-tl-ansible/install-tl.profile"
@@ -43,6 +51,7 @@
   when: texdir_path.stat.exists == false
 
 - name: texlive | install texlive
+  become: yes
   command: ./install-tl -profile install-tl.profile
   args:
     chdir: "{{ texlive_dest }}/tmp/install-tl-ansible"
@@ -50,6 +59,7 @@
   when: texdir_path.stat.exists == false
 
 - name:  texlive | Font config Symlink 
+  become: yes
   file: 
     force: yes
     path: /etc/fonts/conf.d/09-texlive.conf
@@ -57,17 +67,20 @@
     state: link
 
 - name:  texlive | rebuild font cache
+  become: yes
   command: fc-cache -rsfv
   # Only when the texlive_TEXDIR folder was missing when tested at the 
   # start of the play, i.e. it wasn't installed (it will exist now)
   when: texdir_path.stat.exists == false
 
 - name:  texlive | clean up temp installation files dir
+  become: yes
   file: 
     path: "{{ texlive_dest }}/tmp" 
     state: absent
 
 - name: texlive | set the global path to include texlive bin
+  become: yes
   template:
     src: texlive-path.sh.j2
     dest: "/etc/profile.d/texlive-path.sh"

--- a/ansible/roles/upgrade-distpackages/tasks/main.yml
+++ b/ansible/roles/upgrade-distpackages/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for roles/upgrade-distpackages
 
 - name: system packages | upgrade
+  become: yes
   yum:
     name: "{{ item }}"
     state: latest

--- a/ansible/roles/versioncontrol-utils/tasks/main.yml
+++ b/ansible/roles/versioncontrol-utils/tasks/main.yml
@@ -2,11 +2,13 @@
 # tasks file for roles/versioncontrol-utils
 
 - name: system packages | install epel repo
+  become: yes
   yum:
     name: epel-release
-    state: latest
+    state: present
 
 - name: system packages | basic system utils
+  become: yes
   yum:
     name: "{{ item }}"
     state: present


### PR DESCRIPTION
- Use `state: latest` for all package installations apart from explicit upgrades, this will avoid uncessary checks and should prevent unexpected upgrades.
- Use `become: yes` for most tasks. It makes more sense to mark the tasks explicitly as requiring `sudo` instead of specifying it at the command line- this means you don't need the `-b` flag (though you may still need to pass `--ask-become-pass` to pass the sudo password).
- 2131636 uses `become: {{ jenkinsuser }}` for the creation of the virtualenv only
- Currently untested, thought I'd open it in case someone has time and to hopefully avoid merge conflicts