### PR TITLE
Create docker-dev-hosts group (like prod, but with dns)

### DIFF
--- a/ansible/ci-provision.yml
+++ b/ansible/ci-provision.yml
@@ -26,3 +26,21 @@
   - role: basedeps
   - role: upgrade-distpackages
   - role: docker
+
+- hosts: docker-dev-hosts
+  roles:
+  - role: lvm-partition
+    lvm_lvname: root
+    lvm_lvmount: /
+    lvm_lvsize: "{{ rootsize }}"
+    lvm_lvfilesystem: ext4
+  - role: lvm-partition
+    lvm_lvname: scratch
+    lvm_lvmount: /scratch
+    lvm_lvsize: "{{ scratch_size }}"
+    lvm_lvfilesystem: "{{ scratch_filesystem }}"
+  - role: basedeps
+  - role: upgrade-distpackages
+  - role: docker
+  - role: docker-dns-server
+  - role: docker-dns-client


### PR DESCRIPTION
Updating this repo with the current state of docker on `docker-dev-hosts`