### PR TITLE
wip: Move all VIRTUALENV-upgrade items to ansible

### DIFF
--- a/ansible/ci-virtualenv.yml
+++ b/ansible/ci-virtualenv.yml
@@ -1,0 +1,5 @@
+---
+
+- hosts: ci-jenkins-linux
+  roles:
+    - role: jenkinsslave

--- a/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
+++ b/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
@@ -6,7 +6,6 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - python-pip
     - python-virtualenv
     
 - name: virtualenv | scc

--- a/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
+++ b/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
@@ -14,4 +14,4 @@
   become_user: "{{ jenkinsuser }}"
   pip:
     virtualenv: /home/{{ jenkinsuser }}/virtualenv
-    name: scc
+    name: scc Sphinx==1.2.3 genshi virtualenv epydoc yaclifw omego pytest docker-py PyYAML


### PR DESCRIPTION
This is the beginning of the end of the VIRTUALENV{-WIN}-upgrade
jobs. They do not give the flexibility to test what has changed
before we run the upgrade.

----

Following on from gh-28, this adds other package requirements in ansible.
A few questions/comments:

 * [ ] the use of "jenkinsuser" is in the virtualenv tasks. This might be overly coupled if we eventually want to use this elsewhere.
 * [ ] due to that, extra checks are pulled in (Java, etc) which we don't need for just the venv bump. Considering idempotency, do we just assume that's ok?
 * [ ] should we actually be driving this via a `requirements.txt` file?
 * [ ] the `VIRTUALENV-*` jobs did a manual install; are we ok with cleaning that up and moving to the use of packages?

See screenshot below for the current state on octopus.

Follow-up items:
 * [ ] delete jenkins jobs