### PR TITLE
Network bonding, delete/disable unused NICs

### DIFF
--- a/ansible/roles/network/README.md
+++ b/ansible/roles/network/README.md
@@ -3,12 +3,14 @@ Network
 
 Set up custom network interface configurations for a server.
 
+
 Role Variables
 --------------
 
-- `networkifaces`: A list of dictionaries, one per network device, of network parameters which will be substituted into `templates/etc-sysconfig-network-scripts-ifcfg.j2`.
-- `networkifaces[].device`: The device name. All other fields are optional, see the template for details.
-- `networkifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
+- `network_ifaces`: A list of dictionaries, one per network device, of network parameters which will be substituted into `templates/etc-sysconfig-network-scripts-ifcfg.j2`.
+- `network_ifaces[].device`: The device name. All other fields are optional, see the template for details.
+- `network_ifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
+- `network_delete_ifaces`: A list of network device names to be removed.
 
 
 Example Playbook
@@ -18,7 +20,7 @@ Example Playbook
     - hosts: localhost
       roles:
       - role: network
-        networkifaces:
+        network_ifaces:
         - device: eth0
           ip: 192.168.1.1
           netmask: 255.255.255.0
@@ -31,7 +33,7 @@ Example Playbook
     - hosts: localhost
       roles:
       - role: network
-        networkifaces:
+        network_ifaces:
         - device: bond0
           ip: 192.168.1.1
           prefix: 24

--- a/ansible/roles/network/README.md
+++ b/ansible/roles/network/README.md
@@ -10,7 +10,8 @@ Role Variables
 - `network_ifaces`: A list of dictionaries, one per network device, of network parameters which will be substituted into `templates/etc-sysconfig-network-scripts-ifcfg.j2`.
 - `network_ifaces[].device`: The device name. All other fields are optional, see the template for details.
 - `network_ifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
-- `network_delete_ifaces`: A list of network device names to be removed.
+- `network_disable_ifaces`: A list of network device names to be explicitly disabled, use this if you want to be sure the interface is disabled (as opposed to being auto-configured by the system).
+- `network_delete_ifaces`: A regular expression describing the network device name(s) to be removed (note this means the system may auto-configure them), use this for cleaning up spare configuration files.
 
 
 Example Playbook
@@ -51,6 +52,7 @@ Notes
 -----
 
 - If you change the network settings it may be restarted, which means your connection from Ansible may be broken.
+- In some cases restarting the network is insufficient, you may need to reboot.
 - If you are using this role to set a network IP after a system has been PXEed you may need to temporarily set `ansible_host` in your host inventory if DNS isn't already setup for the host.
 
 

--- a/ansible/roles/network/README.md
+++ b/ansible/roles/network/README.md
@@ -8,6 +8,42 @@ Role Variables
 
 - `networkifaces`: A list of dictionaries, one per network device, of network parameters which will be substituted into `templates/etc-sysconfig-network-scripts-ifcfg.j2`.
 - `networkifaces[].device`: The device name. All other fields are optional, see the template for details.
+- `networkifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
+
+
+Example Playbook
+----------------
+
+    # Simple network
+    - hosts: localhost
+      roles:
+      - role: network
+        networkifaces:
+        - device: eth0
+          ip: 192.168.1.1
+          netmask: 255.255.255.0
+          type: ethernet
+          gateway: 192.168.1.254
+          dns1: 8.8.4.4
+          dns2: 8.8.8.8
+
+    # Bonded network combining eth0 and eth1
+    - hosts: localhost
+      roles:
+      - role: network
+        networkifaces:
+        - device: bond0
+          ip: 192.168.1.1
+          prefix: 24
+          gateway: 192.168.1.254
+          dns1: 8.8.4.4
+          dns2: 8.8.8.8
+          bondmaster: bond0
+        - device: eth0
+          bondmaster: bond0
+        - device: eth1
+          bondmaster: bond0
+
 
 Author Information
 ------------------

--- a/ansible/roles/network/README.md
+++ b/ansible/roles/network/README.md
@@ -45,6 +45,13 @@ Example Playbook
           bondmaster: bond0
 
 
+Notes
+-----
+
+- If you change the network settings it may be restarted, which means your connection from Ansible may be broken.
+- If you are using this role to set a network IP after a system has been PXEed you may need to temporarily set `ansible_host` in your host inventory if DNS isn't already setup for the host.
+
+
 Author Information
 ------------------
 

--- a/ansible/roles/network/handlers/main.yml
+++ b/ansible/roles/network/handlers/main.yml
@@ -2,4 +2,5 @@
 # Handler for network configuration
 
 - name: restart network
+  become: yes
   service: name=network state=restarted

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -3,7 +3,10 @@
 
 - name: network | Setup nics
   become: yes
-  template: src=etc-sysconfig-network-scripts-ifcfg.j2 dest=/etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
+  template:
+    backup: yes
+    src: etc-sysconfig-network-scripts-ifcfg.j2
+    dest: /etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
   with_items: networkifaces
   notify:
     - restart network

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -16,7 +16,7 @@
     backup: yes
     src: etc-sysconfig-network-scripts-ifcfg.j2
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
-  with_items: networkifaces
+  with_items: network_ifaces
   notify:
     - restart network
 
@@ -26,7 +26,7 @@
 - name: network | check bonding
   stat:
     path: /proc/net/bonding/{{ item.bondmaster }}
-  with_items: networkifaces
+  with_items: network_ifaces
   when: "'bondmaster' in item"
   register: checkbonds
 

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -1,22 +1,41 @@
 ---
 # Setup network interfaces
 
+- name: network | find unwanted nics
+  become: yes
+  find:
+    paths: /etc/sysconfig/network-scripts/
+    patterns: ifcfg-{{ network_delete_ifaces }}
+    use_regex: True
+  when: network_delete_ifaces is defined and network_delete_ifaces
+  register: unwanted
+
 - name: network | remove nics
   become: yes
   file:
-    path: /etc/sysconfig/network-scripts/ifcfg-{{ item }}
+    path: "{{ item.path }}"
     state: absent
-  with_items: network_delete_ifaces | default ([])
+  with_items: "{{ unwanted.files | default([]) }}"
   notify:
     - restart network
 
-- name: network | Setup nics
+- name: network | setup nics
   become: yes
   template:
     backup: yes
     src: etc-sysconfig-network-scripts-ifcfg.j2
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
   with_items: network_ifaces
+  notify:
+    - restart network
+
+- name: network | disable nics
+  become: yes
+  template:
+    backup: yes
+    src: etc-sysconfig-network-scripts-ifcfg-disabled.j2
+    dest: /etc/sysconfig/network-scripts/ifcfg-{{ item }}
+  with_items: network_disable_ifaces | default([])
   notify:
     - restart network
 

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
 # Setup network interfaces
 
+- name: network | remove nics
+  become: yes
+  file:
+    path: /etc/sysconfig/network-scripts/ifcfg-{{ item }}
+    state: absent
+  with_items: network_delete_ifaces | default ([])
+  notify:
+    - restart network
+
 - name: network | Setup nics
   become: yes
   template:
@@ -10,6 +19,9 @@
   with_items: networkifaces
   notify:
     - restart network
+
+- name: network | restart network if necessary before checking bonding
+  meta: flush_handlers
 
 - name: network | check bonding
   stat:

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -10,3 +10,17 @@
   with_items: networkifaces
   notify:
     - restart network
+
+- name: network | check bonding
+  stat:
+    path: /proc/net/bonding/{{ item.bondmaster }}
+  with_items: networkifaces
+  when: "'bondmaster' in item"
+  register: checkbonds
+
+- name: network | check bonding active
+  assert:
+    that:
+    - "item.stat.exists and not item.stat.isdir"
+  with_items:
+    - "{{ checkbonds.results }}"

--- a/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg-disabled.j2
+++ b/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg-disabled.j2
@@ -1,0 +1,4 @@
+DEVICE={{ item }}
+BOOTPROTO=none
+ONBOOT=no
+NM_CONTROLLED=no

--- a/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -2,8 +2,10 @@ DEVICE={{ item.device }}
 BOOTPROTO=none
 IPV6INIT=yes
 MTU=1500
-NM_CONTROLLED=yes
 ONBOOT=yes
+{% if 'networkmanager' in item %}
+NM_CONTROLLED={{ item.networkmanager }}
+{% endif %}
 {% if 'ip' in item %}
 IPADDR={{ item.ip }}
 {% endif %}

--- a/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -15,8 +15,6 @@ PREFIX={{ item.prefix }}
 {% endif %}
 {% if 'type' in item %}
 TYPE={{ item.type }}
-{% else %}
-TYPE=Ethernet
 {% endif %}
 {% if 'hwaddr' in item %}
 HWADDR={{ item.hwaddr }}

--- a/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -32,3 +32,15 @@ DNS2={{ item.dns2 }}
 BRIDGE={{ item.bridge }}
 {% endif %}
 USERCTL=no
+{% if 'bondmaster' in item %}
+{%   if item.bondmaster == item.device %}
+{%     if 'type' not in item %}
+TYPE=Bond
+{%     endif %}
+BONDING_MASTER=yes
+BONDING_OPTS="resend_igmp=1 updelay=0 use_carrier=1 miimon=100 downdelay=0 xmit_hash_policy=0 primary_reselect=0 fail_over_mac=0 arp_validate=0 mode=active-backup primary=eno1 lacp_rate=0 arp_interval=0 ad_select=0"
+{%   else %}
+MASTER={{ item.bondmaster }}
+SLAVE=yes
+{%   endif %}
+{% endif %}


### PR DESCRIPTION
Support configuration of bonded interfaces, see README for an example.
- `network_disable_ifaces` is to explicity create NIC config files to disable a NIC
- `network_delete_ifaces` is to delete unwanted `ifcfg-.*` files, for instance kickstarting a node may create an interface name which doesn't match the required naming.