### PR TITLE
Start refactoring CI playbooks

### DIFF
--- a/ansible/ci-docker-dev-hosts.yml
+++ b/ansible/ci-docker-dev-hosts.yml
@@ -14,6 +14,7 @@
     lvm_lvsize: "{{ scratch_size }}"
     lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: basedeps
+#  - role: system-monitor-agent
   - role: docker
   - role: docker-dns-server
   - role: docker-dns-client

--- a/ansible/ci-docker-dev-hosts.yml
+++ b/ansible/ci-docker-dev-hosts.yml
@@ -1,0 +1,20 @@
+---
+# Playbook for provisioning Docker development nodes
+
+- hosts: ci-docker-dev-hosts
+  roles:
+  - role: lvm-partition
+    lvm_lvname: root
+    lvm_lvmount: /
+    lvm_lvsize: "{{ rootsize }}"
+    lvm_lvfilesystem: ext4
+  - role: lvm-partition
+    lvm_lvname: scratch
+    lvm_lvmount: /scratch
+    lvm_lvsize: "{{ scratch_size }}"
+    lvm_lvfilesystem: "{{ scratch_filesystem }}"
+  - role: basedeps
+  - role: upgrade-distpackages
+  - role: docker
+  - role: docker-dns-server
+  - role: docker-dns-client

--- a/ansible/ci-docker-dev-hosts.yml
+++ b/ansible/ci-docker-dev-hosts.yml
@@ -15,6 +15,7 @@
     lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: basedeps
 #  - role: system-monitor-agent
+#  - role: versioncontrol-utils
   - role: docker
   - role: docker-dns-server
   - role: docker-dns-client

--- a/ansible/ci-docker-dev-hosts.yml
+++ b/ansible/ci-docker-dev-hosts.yml
@@ -7,7 +7,7 @@
     lvm_lvname: root
     lvm_lvmount: /
     lvm_lvsize: "{{ rootsize }}"
-    lvm_lvfilesystem: ext4
+    lvm_lvfilesystem: "{{ root_filesystem }}"
   - role: lvm-partition
     lvm_lvname: scratch
     lvm_lvmount: /scratch

--- a/ansible/ci-docker-dev-hosts.yml
+++ b/ansible/ci-docker-dev-hosts.yml
@@ -14,7 +14,6 @@
     lvm_lvsize: "{{ scratch_size }}"
     lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: basedeps
-  - role: upgrade-distpackages
   - role: docker
   - role: docker-dns-server
   - role: docker-dns-client

--- a/ansible/ci-docker-prod-hosts.yml
+++ b/ansible/ci-docker-prod-hosts.yml
@@ -15,4 +15,5 @@
     lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: basedeps
   - role: system-monitor-agent
+  - role: versioncontrol-utils
   - role: docker

--- a/ansible/ci-docker-prod-hosts.yml
+++ b/ansible/ci-docker-prod-hosts.yml
@@ -1,13 +1,13 @@
 ---
 # Playbook for provisioning Docker Production nodes
 
-- hosts: ci-docker-dev-hosts
+- hosts: ci-docker-prod-hosts
   roles:
   - role: lvm-partition
     lvm_lvname: root
     lvm_lvmount: /
     lvm_lvsize: "{{ rootsize }}"
-    lvm_lvfilesystem: ext4
+    lvm_lvfilesystem: "{{ root_filesystem }}"
   - role: lvm-partition
     lvm_lvname: scratch
     lvm_lvmount: /scratch
@@ -16,5 +16,3 @@
   - role: basedeps
   - role: upgrade-distpackages
   - role: docker
-  - role: docker-dns-server
-  - role: docker-dns-client

--- a/ansible/ci-docker-prod-hosts.yml
+++ b/ansible/ci-docker-prod-hosts.yml
@@ -1,0 +1,20 @@
+---
+# Playbook for provisioning Docker Production nodes
+
+- hosts: ci-docker-dev-hosts
+  roles:
+  - role: lvm-partition
+    lvm_lvname: root
+    lvm_lvmount: /
+    lvm_lvsize: "{{ rootsize }}"
+    lvm_lvfilesystem: ext4
+  - role: lvm-partition
+    lvm_lvname: scratch
+    lvm_lvmount: /scratch
+    lvm_lvsize: "{{ scratch_size }}"
+    lvm_lvfilesystem: "{{ scratch_filesystem }}"
+  - role: basedeps
+  - role: upgrade-distpackages
+  - role: docker
+  - role: docker-dns-server
+  - role: docker-dns-client

--- a/ansible/ci-docker-prod-hosts.yml
+++ b/ansible/ci-docker-prod-hosts.yml
@@ -14,5 +14,4 @@
     lvm_lvsize: "{{ scratch_size }}"
     lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: basedeps
-  - role: upgrade-distpackages
   - role: docker

--- a/ansible/ci-docker-prod-hosts.yml
+++ b/ansible/ci-docker-prod-hosts.yml
@@ -14,4 +14,5 @@
     lvm_lvsize: "{{ scratch_size }}"
     lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: basedeps
+  - role: system-monitor-agent
   - role: docker

--- a/ansible/ci-initial.yml
+++ b/ansible/ci-initial.yml
@@ -1,0 +1,9 @@
+---
+# Initial configuration of CI nodes
+# Note you should reboot after changing the network configuration, and
+# manually verify that the configuration is correct
+
+- hosts: ci
+  roles:
+  - role: upgrade-distpackages
+  - role: network

--- a/ansible/ci-jenkins-linux.yml
+++ b/ansible/ci-jenkins-linux.yml
@@ -1,0 +1,9 @@
+---
+# Playbook for provisioning Jenkins CI nodes
+
+- hosts: ci-jenkins-linux
+  roles:
+  - role: lvm-partition
+    lvm_lvname: jenkins-workdir
+    lvm_lvmount: "{{ jenkinsworkdir }}"
+    lvm_lvsize: "{{ jenkinssize }}"

--- a/ansible/ci-provision.yml
+++ b/ansible/ci-provision.yml
@@ -1,6 +1,10 @@
 ---
 # Playbook for running all CI provisioning playbooks
 
+# Initial networking and basic system configuration
+# A reboot may be required after this playbook
+- include: ci-initial.yml
+
 # Jenkins CI servers
 - include: ci-jenkins-linux.yml
 

--- a/ansible/ci-provision.yml
+++ b/ansible/ci-provision.yml
@@ -1,46 +1,11 @@
 ---
-# Playbook for provisioning Jenkins CI nodes
+# Playbook for running all CI provisioning playbooks
 
-- hosts: ci-jenkins-linux
-  roles:
-  - role: lvm-partition
-    lvm_lvname: jenkins-workdir
-    lvm_lvmount: "{{ jenkinsworkdir }}"
-    lvm_lvsize: "{{ jenkinssize }}"
+# Jenkins CI servers
+- include: ci-jenkins-linux.yml
 
+# Docker CI hosts
+- include: ci-docker-dev-hosts.yml
 
-# Playbook for provisioning Docker Production nodes
-
-- hosts: docker-prod-hosts
-  roles:
-  - role: lvm-partition
-    lvm_lvname: root
-    lvm_lvmount: /
-    lvm_lvsize: "{{ rootsize }}"
-    lvm_lvfilesystem: ext4
-  - role: lvm-partition
-    lvm_lvname: scratch
-    lvm_lvmount: /scratch
-    lvm_lvsize: "{{ scratch_size }}"
-    lvm_lvfilesystem: "{{ scratch_filesystem }}"
-  - role: basedeps
-  - role: upgrade-distpackages
-  - role: docker
-
-- hosts: docker-dev-hosts
-  roles:
-  - role: lvm-partition
-    lvm_lvname: root
-    lvm_lvmount: /
-    lvm_lvsize: "{{ rootsize }}"
-    lvm_lvfilesystem: ext4
-  - role: lvm-partition
-    lvm_lvname: scratch
-    lvm_lvmount: /scratch
-    lvm_lvsize: "{{ scratch_size }}"
-    lvm_lvfilesystem: "{{ scratch_filesystem }}"
-  - role: basedeps
-  - role: upgrade-distpackages
-  - role: docker
-  - role: docker-dns-server
-  - role: docker-dns-client
+# Docker production hosts
+- include: ci-docker-prod-hosts.yml

--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -6,10 +6,12 @@
   - role: server-swap
   - role: network
   - role: docker-storage
+# TODO: lvm_lvfilesystem: root?
   - role: lvm-partition
     lvm_lvname: scratch
     lvm_lvmount: /scratch
     lvm_lvsize: "{{ scratchsize }}"
+# TODO: lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: lvm-partition
     lvm_lvname: idrdata1
     lvm_lvmount: /idr
@@ -24,7 +26,7 @@
     lvm_lvname: root
     lvm_lvmount: /
     lvm_lvsize: "{{ rootsize }}"
-    lvm_lvfilesystem: ext4
+    lvm_lvfilesystem: "{{ root_filesystem }}"
   - role: lvm-partition
     lvm_lvname: scratch
     lvm_lvmount: /scratch

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -15,14 +15,16 @@ Defaults: `defaults/main.yml`
 
 Custom storage: If `docker_use_custom_storage` is `True` thin-pool logical volumes will be created for Docker, and a separate logical volume will be created for the Docker volume (`/var/lib/docker`).
 This is highly recommended for production use.
+
+- `docker_basefs`: Filesystem to use for the Docker containers (default xfs)
+- `docker_lvfilesystem`: Filesystem for the Docker volume (default xfs)
+
 The following variables must be defined:
 
 - `docker_vgname`: LVM volume group for the logical volumes
 - `docker_poolsize`: Size of the Docker thin-pool partition
 - `docker_metadatasize`: Size of the Docker thin-pool metadata partition (try 1% of the poolsize)
-- `docker_basefs`: Filesystem to use for the Docker containers (e.g. ext4, xfs)
 - `docker_volumesize`: Size of the Docker volume
-- `docker_lvfilesystem`: Filesystem for the Docker volume
 
 Custom networking: If `docker_use_custom_network` is `True` a custom network bridge will be used, this must be created outside of this role.
 The following variables must be defined:

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -13,3 +13,9 @@ docker_use_custom_network: False
 
 # Any other arguments to be passed to the docker daemon
 docker_additional_args:
+
+# Filesystem to use for the Docker containers
+docker_basefs: xfs
+
+# Filesystem for the Docker volume
+docker_lvfilesystem: xfs

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -25,7 +25,7 @@
     backup: yes
     src: etc-sysconfig-network-scripts-ifcfg.j2
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
-  with_items: network_ifaces
+  with_items: network_ifaces | default([])
   notify:
     - restart network
 


### PR DESCRIPTION
### Split CI-playbooks
- `ci-provision.yml` is now the run-everything playbook, and is made up of individual playbooks named after groups, which can be run independently. (Remember a host can be a member of multiple groups, so this allows you to manage one piece of "functionality" of a node)

- You can run `ci-provision.yml` with `--limit` to provision a new node, but if you are doing any hardware configuration it's a good idea to reboot in between. E.g. If you are reconfiguring the network run `ci-initial.yml` first, reboot, then run your other playbook, or just run the parent `ci-provision.yml` since Ansible is idempotent.

Note: I've started doing something similar with the IDR playbooks, but it made more sense to sort out ci-docker first. Also once everyone's happy with a workflow I'll add some docs (basically the above paragraphs).

### Tidied up some vars:

- There's no need to force `docker_basefs` `docker_lvfilesystem` to be defined when they could be set as defaults in the role.
- Added `root_filesystem` to idr playbooks for consistency.
- Made `network/network_ifaces` var optional, this means you can run `ci-initial.yml` for any node and if you haven't configured any sepcial networking the playbook will still run.