### PR TITLE
Docker default filesystems

### DIFF
--- a/ansible/idr-provision.yml
+++ b/ansible/idr-provision.yml
@@ -6,10 +6,12 @@
   - role: server-swap
   - role: network
   - role: docker-storage
+# TODO: lvm_lvfilesystem: root?
   - role: lvm-partition
     lvm_lvname: scratch
     lvm_lvmount: /scratch
     lvm_lvsize: "{{ scratchsize }}"
+# TODO: lvm_lvfilesystem: "{{ scratch_filesystem }}"
   - role: lvm-partition
     lvm_lvname: idrdata1
     lvm_lvmount: /idr
@@ -24,7 +26,7 @@
     lvm_lvname: root
     lvm_lvmount: /
     lvm_lvsize: "{{ rootsize }}"
-    lvm_lvfilesystem: ext4
+    lvm_lvfilesystem: "{{ root_filesystem }}"
   - role: lvm-partition
     lvm_lvname: scratch
     lvm_lvmount: /scratch

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -15,14 +15,16 @@ Defaults: `defaults/main.yml`
 
 Custom storage: If `docker_use_custom_storage` is `True` thin-pool logical volumes will be created for Docker, and a separate logical volume will be created for the Docker volume (`/var/lib/docker`).
 This is highly recommended for production use.
+
+- `docker_basefs`: Filesystem to use for the Docker containers (default xfs)
+- `docker_lvfilesystem`: Filesystem for the Docker volume (default xfs)
+
 The following variables must be defined:
 
 - `docker_vgname`: LVM volume group for the logical volumes
 - `docker_poolsize`: Size of the Docker thin-pool partition
 - `docker_metadatasize`: Size of the Docker thin-pool metadata partition (try 1% of the poolsize)
-- `docker_basefs`: Filesystem to use for the Docker containers (e.g. ext4, xfs)
 - `docker_volumesize`: Size of the Docker volume
-- `docker_lvfilesystem`: Filesystem for the Docker volume
 
 Custom networking: If `docker_use_custom_network` is `True` a custom network bridge will be used, this must be created outside of this role.
 The following variables must be defined:

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -13,3 +13,9 @@ docker_use_custom_network: False
 
 # Any other arguments to be passed to the docker daemon
 docker_additional_args:
+
+# Filesystem to use for the Docker containers
+docker_basefs: xfs
+
+# Filesystem for the Docker volume
+docker_lvfilesystem: xfs


### PR DESCRIPTION
Small cleanup- make some mandatory vars optional.

Note `ansible/idr-provision.yml` group `idr-docker` is out of date (uses the old docker role) so probably best to ignore it.