### PR TITLE
Add roles for connecting a VM to active directory, and for creating samba shares

### DIFF
--- a/ansible/idr-samba-hosts.yml
+++ b/ansible/idr-samba-hosts.yml
@@ -1,0 +1,6 @@
+---
+# Playbook for maintaining IDR Samba nodes
+
+- hosts: idr-samba-hosts
+  roles:
+  - role: active-directory-samba-share

--- a/ansible/roles/active-directory-join/README.md
+++ b/ansible/roles/active-directory-join/README.md
@@ -1,0 +1,27 @@
+Active Directory Join
+=====================
+
+Join a Linux server to an existing Active Directory domain.
+
+
+Role Variables
+--------------
+
+`active_directory_realm`: The main AD domain
+`active_directory_workgroup`: The samba workgroup
+`active_directory_server`: A list of the AD servers
+`active_directory_realmd_tags`: A list of AD realm tags
+`active_directory_kerberos_realms`: A dict of the form `{REALM: [domain, ...]}` where keys are the realms and values are a list of domains associated with that realm
+
+`active_directory_join_ou`: The domain/unit the server should be joined to
+`active_directory_join_user`: The `username%password` of the AD administrative account used to join the node
+`active_directory_join_access`: A list of user and/or group names that should be allowed to access this node
+`active_directory_sssd_conf`: A variable containing the contents of `/etc/sssd/sssd.conf`, so that the contents of the file can be kept in a separate private repository
+`active_directory_ssh_passwords`: `yes|no`, whether ssh access using passwords should be allowed, if omitted do not change the current configuration
+`active_directory_user_homes`: The parent directory for user homes, required if they should be auto-created on login
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/active-directory-join/handlers/main.yml
+++ b/ansible/roles/active-directory-join/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+# Handlers for active-directory-join
+
+- name: restart sshd
+  become: yes
+  service:
+    name: sshd
+    state: restarted
+
+- name: restart sssd
+  become: yes
+  service:
+    name: sssd
+    state: restarted

--- a/ansible/roles/active-directory-join/tasks/main.yml
+++ b/ansible/roles/active-directory-join/tasks/main.yml
@@ -1,0 +1,113 @@
+---
+# tasks file for roles/active-directory-join
+
+- name: system packages | active directory client
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - adcli
+    - krb5-workstation
+    - oddjob
+    - oddjob-mkhomedir
+    - pam_krb5
+    - policycoreutils-python
+    - samba-common
+    - sssd
+
+- name: active directory | authconfig
+  become: yes
+  command: authconfig --enableshadow --passalgo=sha512 --disableldap --disableldapauth --enablekrb5 --krb5realm={{ active_directory_realm }} --enablekrb5kdcdns --enablekrb5realmdns --smbsecurity=ads --smbworkgroup={{ active_directory_workgroup }} --smbrealm={{ active_directory_realm }} --enablelocauthorize --enablemkhomedir --enablepamaccess --enablesssd --enablesssdauth --update
+  args:
+    # This file is actually created by the "active directory | join domain"
+    # task later on, however if it exists we know this step has already
+    # been run
+    creates: /etc/krb5.keytab
+
+# This must be run after authconfig since it modifies the generated config
+- name: active directory | configure smb kerberos
+  become: yes
+  lineinfile:
+    backup: yes
+    dest: /etc/samba/smb.conf
+    line: "kerberos method = secrets and keytab"
+    regexp: '^[\s]*kerberos method\s.*='
+    state: present
+
+- name: active directory | join domain
+  become: yes
+  command: net ads join createcomputer={{ active_directory_join_ou }} -U {{ active_directory_join_user }}
+  args:
+    creates: /etc/krb5.keytab
+
+- name: active directory | configure sssd
+  become: yes
+  template:
+    backup: yes
+    dest: /etc/sssd/sssd.conf
+    mode: 0600
+    src: sssd-sssd-conf.j2
+  notify:
+    - restart sssd
+
+- name: active directory | configure krb5
+  become: yes
+  template:
+    backup: yes
+    dest: /etc/krb5.conf
+    src: krb5-conf.j2
+
+- name: active directory | enable sssd
+  become: yes
+  service:
+    enabled: yes
+    name: sssd
+
+- name: active directory | configure access.conf
+  become: yes
+  template:
+    backup: yes
+    dest: /etc/security/access.conf
+    src: security-access-conf.j2
+
+- name: active directory | enable ssh access
+  become: yes
+  lineinfile:
+    backup: yes
+    create: no
+    dest: /etc/ssh/sshd_config
+    line: "PasswordAuthentication {{ active_directory_ssh_passwords | ternary('yes', 'no') }}"
+    mode: 0600
+    regexp: '^[\s]*PasswordAuthentication\s.*'
+    state: present
+  when: active_directory_ssh_passwords is defined
+  notify:
+    - restart sshd
+
+- name: active directory | selinux status
+  command: /sbin/getenforce
+  register: selinux_status
+  changed_when: False
+
+- name: active directory | check selinux homes
+  become: yes
+  command: grep "/homes /home" /etc/selinux/targeted/contexts/files/file_contexts.subs
+  register: selinux_homes
+  failed_when: False
+  changed_when: False
+
+- name: active directory | create user homes
+  become: yes
+  file:
+    path: "{{ active_directory_user_homes }}"
+    seuser: system_u
+    serole: object_r
+    setype: home_root_t
+    state: directory
+  when: active_directory_user_homes | default(None)
+
+- name: active directory | set selinux homes policy
+  become: yes
+  command: semanage fcontext -a -e /home {{ active_directory_user_homes }}
+  when: (selinux_status.stdout != "Disabled") and (selinux_homes.rc > 0) and (active_directory_user_homes | default(None))

--- a/ansible/roles/active-directory-join/tasks/main.yml
+++ b/ansible/roles/active-directory-join/tasks/main.yml
@@ -8,6 +8,7 @@
     state: present
   with_items:
     - adcli
+    - authconfig
     - krb5-workstation
     - oddjob
     - oddjob-mkhomedir

--- a/ansible/roles/active-directory-join/tasks/main.yml
+++ b/ansible/roles/active-directory-join/tasks/main.yml
@@ -31,7 +31,7 @@
   lineinfile:
     backup: yes
     dest: /etc/samba/smb.conf
-    line: "kerberos method = secrets and keytab"
+    line: "    kerberos method = secrets and keytab"
     regexp: '^[\s]*kerberos method\s.*='
     state: present
 

--- a/ansible/roles/active-directory-join/templates/krb5-conf.j2
+++ b/ansible/roles/active-directory-join/templates/krb5-conf.j2
@@ -1,0 +1,35 @@
+[logging]
+default = FILE:/var/log/krb5libs.log
+kdc = FILE:/var/log/krb5kdc.log
+admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+default_realm = {{ active_directory_realm }}
+dns_lookup_realm = true
+dns_lookup_kdc = true
+ticket_lifetime = 24h
+renew_lifetime = 7d
+forwardable = yes
+rdns = false
+
+[realms]
+{% for item in active_directory_kerberos_realms %}
+{{ item }} = {
+}
+{% endfor %}
+
+[domain_realm]
+{% for item in active_directory_kerberos_realms %}
+{%   for value in active_directory_kerberos_realms[item] %}
+{{ value }} = {{ item }}
+{%   endfor %}
+{% endfor %}
+
+[appdefaults]
+pam = {
+  debug = false
+  ticket_lifetime = 36000
+  renew_lifetime = 36000
+  forwardable = true
+  krb4_convert = false
+}

--- a/ansible/roles/active-directory-join/templates/security-access-conf.j2
+++ b/ansible/roles/active-directory-join/templates/security-access-conf.j2
@@ -1,0 +1,4 @@
+{% for item in active_directory_join_access %}
++:{{ item }}:ALL
+{% endfor %}
+-:ALL EXCEPT root:ALL

--- a/ansible/roles/active-directory-join/templates/sssd-sssd-conf.j2
+++ b/ansible/roles/active-directory-join/templates/sssd-sssd-conf.j2
@@ -1,0 +1,26 @@
+[sssd]
+domains = {{ active_directory_realm | lower }}
+config_file_version = 2
+services = nss, pam, pac
+
+[domain/{{ active_directory_realm | lower }}]
+id_provider = ad
+ad_domain = {{ active_directory_realm | lower }}
+ad_server = {{ active_directory_server }}
+auth_provider = ad
+chpass_provider = ad
+access_provider = ad
+
+krb5_realm = {{ active_directory_realm }}
+realmd_tags = {{ active_directory_realmd_tags }}
+cache_credentials = True
+krb5_store_password_if_offline = True
+default_shell = /bin/bash
+
+ldap_schema = ad
+ldap_id_mapping = False
+
+use_fully_qualified_names = False
+fallback_homedir = /home/%u
+
+cache_credentials = true

--- a/ansible/roles/active-directory-samba-share/README.md
+++ b/ansible/roles/active-directory-samba-share/README.md
@@ -1,0 +1,42 @@
+Active Directory Samba Share
+============================
+
+Manage samba file shares with authentication provided by active directory.
+If the `active-directory-join` role is also present on this server it should be run before this role, and common variables must match.
+
+If you are running SELinux see http://selinuxproject.org/page/SambaRecipes
+
+
+Role Variables
+--------------
+
+`active_directory_realm`: The main AD domain
+`active_directory_workgroup`: The samba workgroup
+`active_directory_shares`: A dictionary of dictionaries of shares in the form `{share-name: { path: , comment: (optional), readonly: (default True), users: [list of users/groups] }}`
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+      - role: active-directory-samba-share
+        active_directory_realm: AD.EXAMPLE.ORG
+        active_directory_workgroup: workgroup
+        active_directory_shares:
+          share-ro:
+            path: /srv/samba/ro
+            comment: Read-only share
+            users: [root]
+
+          share-rw:
+            path: /srv/samba/rw
+            comment: Read-write share
+            readonly: False
+            users: [root]
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/active-directory-samba-share/defaults/main.yml
+++ b/ansible/roles/active-directory-samba-share/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for roles/active-direcgtory-samba
+
+# A dictionary of dictionaries of shares, see README.md
+active_directory_shares: {}

--- a/ansible/roles/active-directory-samba-share/handlers/main.yml
+++ b/ansible/roles/active-directory-samba-share/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Handlers for active-directory-samba-share
+
+- name: restart smb
+  become: yes
+  service:
+    name: smb
+    state: restarted

--- a/ansible/roles/active-directory-samba-share/tasks/main.yml
+++ b/ansible/roles/active-directory-samba-share/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+# tasks file for roles/active-directory-samba-share
+
+- name: system packages | samba server
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - samba
+    - samba-client
+
+- name: samba server | configure shares
+  become: yes
+  template:
+    backup: yes
+    dest: /etc/samba/smb.conf
+    src: samba-smb-conf.j2
+    validate: "testparm -s %s"
+  notify:
+    - restart smb
+
+- name: active directory | enable smb
+  become: yes
+  service:
+    enabled: yes
+    name: smb

--- a/ansible/roles/active-directory-samba-share/templates/samba-smb-conf.j2
+++ b/ansible/roles/active-directory-samba-share/templates/samba-smb-conf.j2
@@ -1,0 +1,24 @@
+[global]
+    workgroup = {{ active_directory_workgroup }}
+    realm = {{ active_directory_realm }}
+    security = ads
+    #idmap config * : range = 16777216-33554431
+    kerberos method = secrets and keytab
+    template shell = /bin/bash
+    server string = Samba Server Version %v
+    # logs split per machine
+    log file = /var/log/samba/log.%m
+    # max 50KB per log file, then rotate
+    max log size = 50
+    passdb backend = tdbsam
+    load printers = no
+    cups options = raw
+    printcap name = /dev/null
+
+{% for key, value in active_directory_shares.iteritems() %}
+[{{ key }}]
+    path = {{ value.path }}
+    comment = {{ value.comment  | default(key) }}
+    read only = {{ (value.readonly | default(True)) | ternary("yes", "no") }}
+    valid users = {{ value.users | join(", ") }}
+{% endfor %}


### PR DESCRIPTION
`active-directory-join`: Take a clean CentOS 7 VM, run this with a host-vars file including AD username/password, and you should be able to ssh in with ldap.

`active-directory-samba-share`: See the readme for an example config for setting up samba shares. This is not dependent on `active-directory-join`, but it does assume AD has already been configured.

Docker might work too (untested).