### PR TITLE
Vagrant-based tests for infrastructure

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+*.un~

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -1,0 +1,23 @@
+# This guide is optimized for Vagrant 1.7 and above.
+# Although versions 1.6.x should behave very similarly, it is recommended
+# to upgrade instead of disabling the requirement below.
+#
+# See: http://docs.ansible.com/ansible/guide_vagrant.html
+Vagrant.require_version ">= 1.7.0"
+
+Vagrant.configure(2) do |config|
+
+  config.vm.define "docker" do |docker|
+    docker.vm.box = "centos/7"
+    docker.vm.provision "ansible" do |ansible|
+      ansible.verbose = "v"
+      ansible.playbook = "test.yml"
+    end
+  end
+
+  # Disable the new default behavior introduced in Vagrant 1.7, to
+  # ensure that all Vagrant machines will use the same SSH key pair.
+  # See https://github.com/mitchellh/vagrant/issues/5005
+  config.ssh.insert_key = false
+
+end

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -15,6 +15,14 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "samba" do |samba|
+    samba.vm.box = "centos/7"
+    samba.vm.provision "ansible" do |ansible|
+      ansible.verbose = "v"
+      ansible.playbook = "test.yml"
+    end
+  end
+
   # Disable the new default behavior introduced in Vagrant 1.7, to
   # ensure that all Vagrant machines will use the same SSH key pair.
   # See https://github.com/mitchellh/vagrant/issues/5005

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -9,3 +9,20 @@
 - hosts: docker
   roles:
   - role: docker
+
+- hosts: samba
+  roles:
+  - role: active-directory-samba-share
+    active_directory_realm: AD.EXAMPLE.ORG
+    active_directory_workgroup: workgroup
+    active_directory_shares:
+      share-ro:
+        path: /srv/samba/ro
+        comment: Read-only share
+        users: [root]
+
+      share-rw:
+        path: /srv/samba/rw
+        comment: Read-write share
+        readonly: False
+        users: [root]

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -1,0 +1,11 @@
+---
+# Playbook for testing individual and sets of roles.
+#
+# Host names in this file should match the name of the Vagrant configuration
+# in Vagrantfile. Tests can be run either by using `vagrant up $NAME` when a
+# box does not yet exist, or `vagrant provision $NAME` for one that exists &
+# is running.
+
+- hosts: docker
+  roles:
+  - role: docker


### PR DESCRIPTION
Used this infrastructure to test https://github.com/openmicroscopy/infrastructure/pull/57

First run showed:

![screen shot 2016-03-14 at 10 59 02](https://cloud.githubusercontent.com/assets/88113/13740979/e087e864-e9d3-11e5-83ad-884de6a23121.png)


Second run showed:

![screen shot 2016-03-14 at 10 58 39](https://cloud.githubusercontent.com/assets/88113/13740982/e5d4c972-e9d3-11e5-971d-3c7d1ea88666.png)
