### PR TITLE
Initial role for managing sudoers, role for analysis tools, idr-analysis playbook

### DIFF
--- a/ansible/idr-analysis.yml
+++ b/ansible/idr-analysis.yml
@@ -1,6 +1,8 @@
 ---
 # Playbook for maintaining IDR Samba nodes
 
-- hosts: idr-sudoers
+- hosts: idr-analysis
   roles:
+  - role: analysis-tools
+  - role: samba-client
   - role: sudoers

--- a/ansible/idr-sudoers.yml
+++ b/ansible/idr-sudoers.yml
@@ -1,0 +1,6 @@
+---
+# Playbook for maintaining IDR Samba nodes
+
+- hosts: idr-sudoers
+  roles:
+  - role: sudoers

--- a/ansible/roles/analysis-tools/README.md
+++ b/ansible/roles/analysis-tools/README.md
@@ -1,0 +1,18 @@
+Analysis Tools
+==============
+
+Useful tools for running high-throughput analyses.
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+      - role: analysis-tools
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/analysis-tools/meta/main.yml
+++ b/ansible/roles/analysis-tools/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- { role: basedeps }

--- a/ansible/roles/analysis-tools/tasks/main.yml
+++ b/ansible/roles/analysis-tools/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for roles/analysis-tools
+
+- name: system packages | analysis utils
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - moreutils-parallel

--- a/ansible/roles/sudoers/README.md
+++ b/ansible/roles/sudoers/README.md
@@ -1,0 +1,33 @@
+Sudoers
+=======
+
+Configure sudoers.
+
+TODO: Expand this role
+
+
+Role Variables
+--------------
+
+- `sudoers_individual_commands`: List of dictionaries with keys: `[{user: username, become: becomeuser, command: "/usr/bin/command args" }]`
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+      - role: sudoers
+        sudoers_individual_commands:
+        - user: user1
+          become: root
+          command: /usr/bin/mount *
+        - user: user2
+          become: root
+          command: /usr/bin/less /var/log/*
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/sudoers/tasks/main.yml
+++ b/ansible/roles/sudoers/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# Configure sudo
+
+- name: system packages | install sudo
+  become: yes
+  yum:
+    pkg: "{{ item }}"
+    state: present
+  with_items:
+    - sudo
+
+- name: sudo | enable sudoers.d
+  become: yes
+  lineinfile:
+    backup: yes
+    dest: /etc/sudoers
+    line: '#includedir /etc/sudoers.d'
+    state: present
+    validate: visudo -cf %s
+
+- name: sudo | setup individual users and commands
+  become: yes
+  template:
+    src: sudoers-individual_commands.j2
+    dest: /etc/sudoers.d/sudoers-individual_commands
+    backup: no
+    validate: visudo -cf %s
+  with_items: sudoers_individual_commands
+  when: sudoers_individual_commands | default([])

--- a/ansible/roles/sudoers/templates/sudoers-individual_commands.j2
+++ b/ansible/roles/sudoers/templates/sudoers-individual_commands.j2
@@ -1,0 +1,3 @@
+{% for item in sudoers_individual_commands %}
+{{ item.user }} ALL=({{ item.become }}) {{ item.command }}
+{% endfor %}


### PR DESCRIPTION
`sudoers` should do the job for now, though there's room for improvement.
`analysis-tools` just installs `parallel` for now, but should be extended if other tools are required.
`idr-analysis.yml` playbook includes the two roles above, plus samba-client to ensure `smbclient` and `mount.cifs` are installed.