### PR TITLE
docker: add docker-compose installation to the role

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,10 @@ Playbooks which do not alter hardware can often be tested in Docker instead of a
     ssh-copy-id omero@172.17.1.1
     # Pass -K if sudo requires a password, and -k if ssh keys aren't setup
     ansible-playbook -i etc/test-hosts -u omero ci-deployment.yml -bv
+
+Alternatively, if you have vagrant installed, you can use any of the targets from Vagrantfile for testing. The definition of the hosts is test.yml.
+
+    # First run this creates, starts, and provisions a new machine.
+    vagrant up docker
+    # Subsequent runs of `provision` re-run ansible on the host.
+    vagrant provision docker

--- a/ansible/roles/docker/tasks/docker-common.yml
+++ b/ansible/roles/docker/tasks/docker-common.yml
@@ -16,3 +16,23 @@
     append: yes
   with_items: docker_groupmembers
   when: docker_groupmembers is defined
+
+# Install extra dependencies (globally)
+
+- name: system packages | install epel
+  become: yes
+  yum:
+    pkg: epel-release
+    state: present
+
+- name: system packages | install pip
+  become: yes
+  yum:
+    pkg: python-pip
+    state: present
+
+- name: pip | install docker-compose
+  become: yes
+  pip:
+    name: docker-compose
+    state: present

--- a/ansible/roles/docker/tasks/docker-common.yml
+++ b/ansible/roles/docker/tasks/docker-common.yml
@@ -31,8 +31,16 @@
     pkg: python-pip
     state: present
 
+- name: pip | install six
+  become: yes
+  pip:
+    name: six
+    state: present
+    version: 1.10.0
+
 - name: pip | install docker-compose
   become: yes
   pip:
     name: docker-compose
     state: present
+    version: 1.6.2

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -49,9 +49,15 @@
   when: "'bondmaster' in item"
   register: checkbonds
 
+- debug:
+    msg: "checkbonds.results.item: {{ item }}"
+  with_items:
+    - "{{ checkbonds.results }}"
+
 - name: network | check bonding active
   assert:
     that:
     - "item.stat.exists and not item.stat.isdir"
+  when: not item.skipped
   with_items:
     - "{{ checkbonds.results }}"


### PR DESCRIPTION
This currently installs globally via python-pip from EPEL.