### PR TITLE
Network check bonding skip

### DIFF
--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -49,10 +49,10 @@
   when: "'bondmaster' in item"
   register: checkbonds
 
-- debug:
-    msg: "checkbonds.results.item: {{ item }}"
-  with_items:
-    - "{{ checkbonds.results }}"
+#- debug:
+#    msg: "checkbonds.results.item: {{ item }}"
+#  with_items:
+#    - "{{ checkbonds.results }}"
 
 - name: network | check bonding active
   assert:

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -58,6 +58,7 @@
   assert:
     that:
     - "item.stat.exists and not item.stat.isdir"
-  when: not item.skipped
+  # 'skipped' field may be missing if it wasn't skipped
+  when: not item.skipped | default (False)
   with_items:
     - "{{ checkbonds.results }}"

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -25,7 +25,7 @@
     backup: yes
     src: etc-sysconfig-network-scripts-ifcfg.j2
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
-  with_items: network_ifaces | default([])
+  with_items: "{{ network_ifaces | default([]) }}"
   notify:
     - restart network
 
@@ -35,7 +35,7 @@
     backup: yes
     src: etc-sysconfig-network-scripts-ifcfg-disabled.j2
     dest: /etc/sysconfig/network-scripts/ifcfg-{{ item }}
-  with_items: network_disable_ifaces | default([])
+  with_items: "{{ network_disable_ifaces | default([]) }}"
   notify:
     - restart network
 
@@ -45,7 +45,7 @@
 - name: network | check bonding
   stat:
     path: /proc/net/bonding/{{ item.bondmaster }}
-  with_items: network_ifaces
+  with_items: "{{ network_ifaces | default([]) }}"
   when: "'bondmaster' in item"
   register: checkbonds
 
@@ -60,5 +60,4 @@
     - "item.stat.exists and not item.stat.isdir"
   # 'skipped' field may be missing if it wasn't skipped
   when: not item.skipped | default (False)
-  with_items:
-    - "{{ checkbonds.results }}"
+  with_items: "{{ checkbonds.results }}"


### PR DESCRIPTION
70dfcf261b531feed8751f5e57b82b709bba3b6e Fixes an error where if an item was not skipped `item.skip` field may not exist. I don't know whether this is an error I missed before, or whether its a change in Ansible.

The remaining commits fix deprecation warnings for this role only.