### PR TITLE
Allow external connections to postgresql server

### DIFF
--- a/ansible/roles/postgresql/README.md
+++ b/ansible/roles/postgresql/README.md
@@ -13,6 +13,13 @@ Defaults: `defaults/main.yml`
 - `postgresql_version`: The PostgreSQL version, either 9.4 (default) or 9.3
 - `postgresql_install_server`: If True (default) install and initialise the server, otherwise only install the client
 - `postgresql_users_databases`: List of dictionaries of users and databases in the form `[{user: db-user, password: db-password, databases: [List of database names]}]`, only works if `postgresql_install_server` is `True`
+- `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `'*'` for all
+- `postgresql_server_auth_local`: Whether to allow the default postgres local authentication (default `True`)
+- `postgresql_server_auth`: List of dictionaries of authorisation parameters, if omitted the default local authentication only will be enabled. Items should be of the form:
+  - `database`: Name of the database
+  - `user`: Username
+  - `address`: Address from which connections will be made
+  - `method`: Ignore this unless you really know what you are doing
 
 
 Example Playbook
@@ -22,6 +29,11 @@ Example Playbook
       roles:
       - postgresql
       vars:
+      - postgresql_server_listen: "'*'"
+      - postgresql_server_auth:
+        - database: publicdb
+          user: alice123
+          address: 192.168.1.0/24
       - postgresql_users_databases:
         - user: alice
           password: alice123

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for roles/postgres
+# defaults file for roles/postgresql
 
 # Version of postgres (see vars)
 postgresql_version: "9.4"
@@ -9,3 +9,12 @@ postgresql_install_server: True
 
 # List of dictionaries containing user and databases information
 postgresql_users_databases: []
+
+# Network interfaces to listen on
+postgresql_server_listen: localhost
+
+# Whether to enable the default local authentication methods
+postgresql_server_auth_local: True
+
+# List of dictionaries of client authorisation lines
+postgresql_server_auth: []

--- a/ansible/roles/postgresql/handlers/main.yml
+++ b/ansible/roles/postgresql/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Handler for postgresql
+
+- name: restart postgresql
+  service:
+    name: postgresql-{{ postgresql_version }}
+    state: restarted

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for roles/postgres
+# tasks file for roles/postgresql
 
 - name: postgres | setup repository
   become: yes
@@ -27,6 +27,30 @@
     creates: "{{ postgresql_datadir }}/PG_VERSION"
   environment:
     PGSETUP_INITDB_OPTIONS: --encoding=UTF8 --locale=en_US.UTF-8 --auth-host=md5
+  when: postgresql_install_server
+
+- name: postgres | set listen interfaces directory
+  become: yes
+  lineinfile:
+    backup: yes
+    dest: "{{ postgresql_datadir }}/postgresql.conf"
+    group: postgres
+    line: "listen_addresses = {{ postgresql_server_listen }}"
+    owner: postgres
+    regexp: "^listen_addresses\\s*="
+    state: present
+  notify:
+    - restart postgresql
+  when: postgresql_install_server
+
+- name: postgres | configure client authorisation
+  become: yes
+  template:
+    backup: yes
+    dest: "{{ postgresql_datadir }}/pg_hba.conf"
+    src: pg_hba-conf.j2
+  notify:
+    - restart postgresql
   when: postgresql_install_server
 
 - name: postgres | start service

--- a/ansible/roles/postgresql/templates/pg_hba-conf.j2
+++ b/ansible/roles/postgresql/templates/pg_hba-conf.j2
@@ -1,0 +1,11 @@
+# PostgreSQL Client Authentication Configuration File (Ansible)
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+{% if postgresql_server_auth_local %}
+local   all             all                                     peer
+host    all             all             127.0.0.1/32            md5
+host    all             all             ::1/128                 md5
+{% endif %}
+
+{% for item in postgresql_server_auth %}
+host {{ item.database }} {{ item.user }} {{ item.address }} {{ item.method | default("md5") }}
+{% endfor %}

--- a/ansible/roles/postgresql/vars/main.yml
+++ b/ansible/roles/postgresql/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-# vars file for roles/postgres
+# vars file for roles/postgresql
 
 postgresql_external:
   repourl:


### PR DESCRIPTION
At the moment only local connections are allowed by default. Added optional parameters `postgresql_server_listen` `postgresql_server_auth` to allow external connections.

This role now assumes full control of `pg_hba.conf`, and also inserts `listen_addresses =` into `postgresql.conf` even if it's the default `localhost`, so you'll see changes against existing uses of this role even though there should be no functional change.