### PR TITLE
Use vdb for omero volume, support custom hostgroups for different environments

### DIFF
--- a/ansible/README-os-idr.md
+++ b/ansible/README-os-idr.md
@@ -1,20 +1,26 @@
 Openstack IDR Playbooks
 =======================
 
-To setup the IDR create a group_vars file if necessary in `inventory/group_vars/`, e.g. `inventory/group_vars/idr.yml`
-This should match the value of the `idr_environment` variable
+To setup the IDR create a group_vars file if necessary in `inventory/group_vars/`, e.g. `inventory/group_vars/os-idr.yml`
+This should match the value of the `idr_environment` variable (default `os-idr`), and can be used to support multiple deployment environments with different variables.
 
 Decide on your openstack dynamic inventory.
 If you are using a single floating IP use `inventory/openstack-private.py`.
 using private internal IPs and a gateway server on the Openstack cloud.
 If you are using floating IPs for all instances you can optionally use `inventory/openstack.py` instead.
 
-TODO: Select your playbook, either `os-idr-uod.yml` for the Dundee cloud or
+Select your playbook, for instance `os-idr-uod.yml` for the Dundee cloud.
 
-For example:
+For example (using the default `os-idr` host-group and variables):
 
-    ansible-playbook -e vm_key_name="KEY_NAME" -e vm_prefix=PREFIX
-        -i inventory/openstack-private.py os-idr-uod.yml
+    ansible-playbook -i inventory/openstack-private.py os-idr-uod.yml
+        -e vm_key_name="KEY_NAME" -e vm_prefix=PREFIX
+
+Or using a custom group called `os-idrstaging` with additional variable overrides:
+
+    ansible-playbook -i inventory/openstack-private.py os-idr-uod.yml
+        -e vm_key_name="KEY_NAME" -e vm_prefix=PREFIX
+        -e @vars/test-overrides.yml -e idr_environment=os-idrstaging
 
 
 Component playbooks

--- a/ansible/README-os-idr.md
+++ b/ansible/README-os-idr.md
@@ -1,7 +1,8 @@
 Openstack IDR Playbooks
 =======================
 
-To setup the IDR create a group_vars file if necessary in `inventory/group_vars/`, e.g. `inventory/group_vars/os-image-centos.yml`
+To setup the IDR create a group_vars file if necessary in `inventory/group_vars/`, e.g. `inventory/group_vars/idr.yml`
+This should match the value of the `idr_environment` variable
 
 Decide on your openstack dynamic inventory.
 If you are using a single floating IP use `inventory/openstack-private.py`.

--- a/ansible/os-create.yml
+++ b/ansible/os-create.yml
@@ -9,10 +9,12 @@
 
   vars:
 
-    omero_vm_groups: "ansible-managed,os-image-centos,omero-hosts"
+    # idr_environment: All VMs will be put into this group, which should have
+    # a matching group_vars file
+    omero_vm_groups: "ansible-managed,os-image-centos,omero-hosts,{{ idr_environment | default('os-idr') }}"
     omero_vm_extra_groups: ""
-    gateway_vm_groups: "ansible-managed,os-image-centos,proxy-hosts"
-    database_vm_groups: "ansible-managed,os-image-centos,database-hosts"
+    gateway_vm_groups: "ansible-managed,os-image-centos,proxy-hosts,{{ idr_environment | default('os-idr') }}"
+    database_vm_groups: "ansible-managed,os-image-centos,database-hosts,{{ idr_environment | default('os-idr') }}"
 
     #vm_prefix:
     #vm_key_name:

--- a/ansible/os-idr-ebi.yml
+++ b/ansible/os-idr-ebi.yml
@@ -25,7 +25,7 @@
 - hosts: omero-hosts
   roles:
   - role: storage-volume-initialise
-    storage_volume_initialise_device: /dev/vdb1
+    storage_volume_initialise_device: /dev/vdb
     storage_volume_initialise_mount: /data
 
 - hosts: proxy-hosts

--- a/ansible/os-idr-uod.yml
+++ b/ansible/os-idr-uod.yml
@@ -23,7 +23,7 @@
 - hosts: omero-hosts
   roles:
   - role: storage-volume-initialise
-    storage_volume_initialise_device: /dev/vdb1
+    storage_volume_initialise_device: /dev/vdb
     storage_volume_initialise_mount: /data
 
 - hosts: proxy-hosts

--- a/ansible/os-omero.yml
+++ b/ansible/os-omero.yml
@@ -19,7 +19,7 @@
     postgresql_users_databases:
     - user: omero
       password: omero
-      databases: [omero]
+      databases: [idr]
     postgresql_server_chown_datadir: True
 
 

--- a/ansible/vars/test-overrides.yml
+++ b/ansible/vars/test-overrides.yml
@@ -1,5 +1,5 @@
-nginx_proxy_ssl_certificate_source_path: ~/ansible-files/letsencrypt/fullchain.pem
-nginx_proxy_ssl_certificate_key_source_path: ~/ansible-files/letsencrypt/privkey.pem
+nginx_proxy_ssl_certificate_source_path: ~/ansible-data/letsencrypt/fullchain.pem
+nginx_proxy_ssl_certificate_key_source_path: ~/ansible-data/letsencrypt/privkey.pem
 
 # Uncomment to enable X-Proxy headers for testing
 nginx_proxy_debug_cache_headers: True

--- a/ansible/vars/test-overrides.yml
+++ b/ansible/vars/test-overrides.yml
@@ -1,0 +1,7 @@
+nginx_proxy_ssl_certificate_source_path: ~/ansible-files/letsencrypt/fullchain.pem
+nginx_proxy_ssl_certificate_key_source_path: ~/ansible-files/letsencrypt/privkey.pem
+
+# Uncomment to enable X-Proxy headers for testing
+nginx_proxy_debug_cache_headers: True
+
+nginx_proxy_set_header_host: '$host'


### PR DESCRIPTION
- All volumes now use the raw disk without partitions (`vdb`)
- group_vars have been moved to the `os-idr` group, so that they can be copied and overriden easily
- See updated README