### PR TITLE
Prod openstack (infra)

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -40,12 +40,6 @@ Vagrant.configure(2) do |config|
     training.vm.provision "ansible" do |ansible|
       ansible.verbose = "v"
       ansible.playbook = "training-server.yml"
-      ansible.extra_vars = {
-        users_to_control_omero: ["centos"],
-        users_to_be_added: ["fm1", "fm2"],
-        users_password: "invalid",
-        fm_groupname: "facility-managers"
-      }
     end
   end
 

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -7,6 +7,10 @@ Vagrant.require_version ">= 1.7.0"
 
 Vagrant.configure(2) do |config|
 
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
   config.vm.define "docker" do |docker|
     docker.vm.box = "centos/7"
     docker.vm.provision "ansible" do |ansible|

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -31,6 +31,14 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "training-server" do |training|
+    training.vm.box = "centos/7"
+    training.vm.provision "ansible" do |ansible|
+      ansible.verbose = "v"
+      ansible.playbook = "training-server.yml"
+    end
+  end
+
   # Disable the new default behavior introduced in Vagrant 1.7, to
   # ensure that all Vagrant machines will use the same SSH key pair.
   # See https://github.com/mitchellh/vagrant/issues/5005

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -40,6 +40,12 @@ Vagrant.configure(2) do |config|
     training.vm.provision "ansible" do |ansible|
       ansible.verbose = "v"
       ansible.playbook = "training-server.yml"
+      ansible.extra_vars = {
+        users_to_control_omero: ["centos"],
+        users_to_be_added: ["fm1", "fm2"],
+        users_password: "invalid",
+        fm_groupname: "facility-managers"
+      }
     end
   end
 

--- a/ansible/os-uod-docker.yml
+++ b/ansible/os-uod-docker.yml
@@ -1,0 +1,95 @@
+---
+# Playbook for starting a docker instance in the
+# openstack cloud.
+
+## See os-create.yml
+
+- hosts: localhost
+  connection: local
+  #gather_facts: false
+
+  vars:
+
+    vm_image: "CentOS 7 1604"
+    vm_flavour: m2.large
+    vm_groups: "ansible-managed,os-image-centos,docker-hosts"
+    vm_extra_groups: ""
+    ignore_internal_known_hosts: True
+
+  pre_tasks:
+
+    - fail:
+        msg: "vm_key_name is required"
+      when: vm_key_name is undefined or not vm_key_name
+
+    - fail:
+        msg: "vm_name is required"
+      when: vm_name is undefined or not vm_name
+
+
+  tasks:
+
+    - set_fact: vm_joined_groups="{{ vm_groups.split(',') | union(vm_extra_groups.split(',')) | join(',')}}"
+
+    - name: Docker external access security group
+      os_security_group:
+        description: External access to Docker servers (managed by Ansible)
+        name: docker-external
+        state: present
+
+    - name: Docker external access security group rules
+      os_security_group_rule:
+        direction: ingress
+        port_range_max: "{{ item }}"
+        port_range_min: "{{ item }}"
+        protocol: tcp
+        remote_ip_prefix: 0.0.0.0/0
+        security_group: docker-external
+        state: present
+      with_items:
+        - 22
+        - 80
+        - 443
+        - 4063
+        - 4064
+        - 8008
+        - 8888
+
+    - name: Docker VM
+      os_server:
+        name: "{{ vm_name }}"
+        state: present
+        image: "{{ vm_image }}"
+        key_name: "{{ vm_key_name }}"
+        flavor: "{{ vm_flavour }}"
+        auto_ip: yes
+        meta:
+          hostname: "{{ vm_name }}"
+          groups: "{{ vm_joined_groups }}"
+        security_groups: [default, docker-external]
+      register: vmdocker
+
+    # To prevent duplicates with the dynamic inventory only add_host if
+    # the VM was created in this run
+
+    - name: Docker VM hosts files
+      add_host:
+        name: "{{ vm_name }}"
+        groups: "{{ vm_joined_groups }}"
+        ansible_host: "{{ vmdocker.server.public_v4 }}"
+        ansible_user: "centos"
+        ansible_become: true
+      when: vmdocker.changed
+
+    - debug:
+        msg: "IPs (Docker) private:{{ vmdocker.openstack.private_v4 }} floating:{{ vmdocker.openstack.public_v4 | default('') }}"
+
+- hosts: localhost
+  connection: local
+  #gather_facts: false
+  roles:
+  - role: openstack-volume-storage
+    openstack_volume_size: 100
+    openstack_volume_vmname: "{{ vm_name }}"
+    openstack_volume_name: varlibdocker
+    openstack_volume_device: /dev/vdb

--- a/ansible/os-uod-docker.yml
+++ b/ansible/os-uod-docker.yml
@@ -13,7 +13,6 @@
     vm_image: "CentOS 7 1604"
     vm_flavour: m2.large
     vm_groups: "ansible-managed,os-image-centos,docker-hosts"
-    vm_extra_groups: ""
     ignore_internal_known_hosts: True
 
   pre_tasks:
@@ -28,8 +27,6 @@
 
 
   tasks:
-
-    - set_fact: vm_joined_groups="{{ vm_groups.split(',') | union(vm_extra_groups.split(',')) | join(',')}}"
 
     - name: Docker external access security group
       os_security_group:
@@ -65,7 +62,7 @@
         auto_ip: yes
         meta:
           hostname: "{{ vm_name }}"
-          groups: "{{ vm_joined_groups }}"
+          groups: "{{ vm_groups }}"
         security_groups: [default, docker-external]
       register: vmdocker
 
@@ -75,11 +72,10 @@
     - name: Docker VM hosts files
       add_host:
         name: "{{ vm_name }}"
-        groups: "{{ vm_joined_groups }}"
+        groups: "{{ vm_groups }}"
         ansible_host: "{{ vmdocker.server.public_v4 }}"
         ansible_user: "centos"
         ansible_become: true
-      when: vmdocker.changed
 
     - debug:
         msg: "IPs (Docker) private:{{ vmdocker.openstack.private_v4 }} floating:{{ vmdocker.openstack.public_v4 | default('') }}"

--- a/ansible/os-uod-web.yml
+++ b/ansible/os-uod-web.yml
@@ -1,0 +1,87 @@
+---
+# Playbook for starting a web instance in the
+# openstack cloud.
+
+## See os-create.yml
+
+- hosts: localhost
+  connection: local
+  #gather_facts: false
+
+  vars:
+
+    vm_image: "CentOS 7 1604"
+    vm_flavour: m1.medium
+    vm_groups: "ansible-managed,os-image-centos,web-linux"
+    ignore_internal_known_hosts: True
+
+  pre_tasks:
+
+    - fail:
+        msg: "vm_key_name is required"
+      when: vm_key_name is undefined or not vm_key_name
+
+    - fail:
+        msg: "vm_name is required"
+      when: vm_name is undefined or not vm_name
+
+
+  tasks:
+
+    - name: Web external access security group
+      os_security_group:
+        description: External access to Web servers (managed by Ansible)
+        name: web-external
+        state: present
+
+    - name: Web external access security group rules
+      os_security_group_rule:
+        direction: ingress
+        port_range_max: "{{ item }}"
+        port_range_min: "{{ item }}"
+        protocol: tcp
+        remote_ip_prefix: 0.0.0.0/0
+        security_group: web-external
+        state: present
+      with_items:
+        - 22 # could be restricted to fewer IPs
+        - 80
+        - 443
+
+    - name: Web VM
+      os_server:
+        name: "{{ vm_name }}"
+        state: present
+        image: "{{ vm_image }}"
+        key_name: "{{ vm_key_name }}"
+        flavor: "{{ vm_flavour }}"
+        auto_ip: yes
+        meta:
+          hostname: "{{ vm_name }}"
+          groups: "{{ vm_groups }}"
+        security_groups: [default, web-external]
+      register: vmweb
+
+    # To prevent duplicates with the dynamic inventory only add_host if
+    # the VM was created in this run
+
+    - name: Web VM hosts files
+      add_host:
+        name: "{{ vm_name }}"
+        groups: "{{ vm_groups }}"
+        ansible_host: "{{ vmweb.server.public_v4 }}"
+        ansible_user: "centos"
+        ansible_become: true
+
+    - debug:
+        msg: "IPs (Web) private:{{ vmweb.openstack.private_v4 }} floating:{{ vmweb.openstack.public_v4 | default('') }}"
+
+- hosts: localhost
+  connection: local
+  #gather_facts: false
+  roles:
+  - role: openstack-volume-storage
+    openstack_volume_size: 100
+    openstack_volume_vmname: "{{ vm_name }}"
+    openstack_volume_name: var
+    openstack_volume_device: /dev/vdb

--- a/ansible/training-server.yml
+++ b/ansible/training-server.yml
@@ -22,7 +22,9 @@
   tasks:
   - name: training-server | add operating system group for trainers
     become: true
-    group: name=trainers state=present
+    group:
+      name: trainers
+      state: present
 
   - name: training-server | add sample images folder
     become: true
@@ -35,7 +37,9 @@
 
   - name: training-server | add operating system group for facility managers
     become: true
-    group: name=facility-managers state=present
+    group:
+      name: facility-managers
+      state: present
 
   - name: training-server | add facility manager operating system users
     become: true

--- a/ansible/training-server.yml
+++ b/ansible/training-server.yml
@@ -14,7 +14,8 @@
     # Variable to tell OMEGO to get Ice 3.5, not the 'latest ice'. Ice role doesn't install latest at the moment, but Ice 3.5.
     omero_omego_additional_args: "--ice 3.5"
 
-    postgresql_users_databases:
+  vars:
+  - postgresql_users_databases:
     - user: omero
       password: omero
       databases: [omero]

--- a/ansible/training-server.yml
+++ b/ansible/training-server.yml
@@ -1,0 +1,84 @@
+# Production tuning of server limits.conf, Postgres and NGINX required, but this will install a minimal OMERO server,
+# OMERO.web with NGINX and systemd configuration controlling both.
+
+# Install the latest release, including PostgreSQL on the same server
+
+# users-to-be-added to come from host_vars
+
+- hosts: training-server
+  roles:
+  - role: omero-server
+    # Taking this from the openstack playbook os-omero.yml, to install the systemd config.
+    omero_systemd_setup: True
+
+    # Variable to tell OMEGO to get Ice 3.5, not the 'latest ice'. Ice role doesn't install latest at the moment, but Ice 3.5.
+    omero_omego_additional_args: "--ice 3.5"
+
+    postgresql_users_databases:
+    - user: omero
+      password: omero
+      databases: [omero]
+
+  tasks:
+  - name: training-server | add operating system group for trainers
+    become: true
+    group: name=trainers state=present
+
+  - name: training-server | add sample images folder
+    become: true
+    file:
+      path: /var/sample-images
+      owner: root
+      group: trainers
+      mode: 0775
+      state: directory
+
+  - name: training-server | add operating system group for facility managers
+    become: true
+    group: name=facility-managers state=present
+
+  - name: training-server | add facility manager operating system users
+    become: true
+    user:
+     name: "{{item}}"
+     state: present
+     groups: users,{{ fm_groupname }}
+     password: "{{ users_password  }}"
+    with_items: "{{ users_to_be_added }}"
+
+  - name: training-server | add symlinks to sample images in fm users homedirs
+    become: true
+    file:
+      path: ~{{ item }}/sample-images
+      owner: root
+      src: /var/sample-images
+      state: link
+    with_items: "{{ users_to_be_added }}"
+
+  - name: training-server | add OMERO.DropBox folders
+    become: true
+    file:
+      path: /OMERO/DropBox/{{ item }}
+      owner: omero
+      group: "{{ fm_groupname  }}"
+      mode: 0775
+      state: directory
+    with_items: "{{ users_to_be_added }}"
+
+  - name: training-server | allow OMERO user sudo by list of users in variable
+    become: true
+    lineinfile:
+      dest: /etc/sudoers
+      state: present
+      line: '{{ item }} ALL=(omero:omero) NOPASSWD:ALL'
+      validate: 'visudo -cf %s'
+    with_items: "{{ users_to_control_omero }}"
+
+  - name: training-server | allow OMERO service control by list of users in variable
+    become: true
+    lineinfile:
+      dest: /etc/sudoers
+      state: present
+      line: '{{ item }} ALL=(root) NOPASSWD:/usr/bin/systemctl ?* omero.service, /usr/bin/systemctl ?* omero-web.service'
+      validate: 'visudo -cf %s'
+    with_items: "{{ users_to_control_omero }}"

--- a/ansible/training-server.yml
+++ b/ansible/training-server.yml
@@ -19,6 +19,13 @@
     - user: omero
       password: omero
       databases: [omero]
+  - users_to_control_omero:
+      - "centos"
+  - users_to_be_added:
+      - "fm1"
+      - "fm2"
+  - users_password: "invalid"
+  - fm_groupname: "facility-managers"
 
   tasks:
   - name: training-server | add operating system group for trainers

--- a/ansible/uod-docker.yml
+++ b/ansible/uod-docker.yml
@@ -1,0 +1,18 @@
+---
+# Playbook for managing a docker instance in the
+# openstack cloud.
+
+- hosts: docker-hosts
+  vars:
+    ansible_user: centos
+  roles:
+  - role: storage-volume-initialise
+    storage_volume_initialise_device: /dev/vdb
+    storage_volume_initialise_mount: /var/lib/docker
+  - role: basedeps
+  - role: system-monitor-agent
+  - role: versioncontrol-utils
+  - role: docker
+    docker_groupmembers: [centos]
+  - role: sudoers
+  - role: local-accounts

--- a/ansible/uod-web.yml
+++ b/ansible/uod-web.yml
@@ -1,0 +1,48 @@
+---
+- name: OME Website Setup
+  hosts: web-linux # TODO?
+  vars:
+    ansible_user: centos
+    site_owner: centos
+    site_group: centos
+    dev_website_root: /var/www/www-dev.openmicroscopy.org/html
+    dev_site_name: www-dev.openmicroscopy.org
+    dev_site_aliases:
+      - web-test.openmicroscopy.org
+    live_website_root: /var/www/www.openmicroscopy.org/html
+    live_site_name: www-live.openmicroscopy.org
+    live_site_aliases:
+      - openmicroscopy.org
+  roles:
+    - nginx
+  pre_tasks:
+    - name: install rubygems for jekyll
+      yum: name=rubygems state=present
+      become: yes
+    - name: install ruby-devel
+      yum: name=ruby-devel state=present
+      become: yes
+  tasks:
+    - name: Install jekyll
+      gem: name=jekyll state=present user_install=no
+      become: yes
+
+    - name: dev website deploy directory
+      file: state=directory dest="{{ dev_website_root }}" owner="{{ site_owner }}" group="{{ site_group }}" mode=0755
+      become: yes
+    - name: nginx configuration for {{ dev_site_name }}
+      template: src=templates/{{ dev_site_name }}.nginx.conf dest=/etc/nginx/conf.d/{{ dev_site_name }}.conf
+      become: yes
+      notify:
+        - reload nginx
+
+    - name: live website deploy directory
+      file: state=directory dest="{{ live_website_root }}" owner="{{ site_owner }}" group="{{ site_group }}" mode=0755
+      become: yes
+    - name: nginx configuration for {{ live_site_name }}
+      template: src=templates/{{ live_site_name }}.nginx.conf dest=/etc/nginx/conf.d/01-{{ live_site_name }}.conf
+      become: yes
+      notify:
+        - reload nginx
+
+  post_tasks:


### PR DESCRIPTION
Few cleanup commits as well as a few new playbooks for getting new production services on openstack:

 * `training-server` migrated from management_tools (thanks @kennethgillen!)
 * playbooks for production docker containers
 * playbooks for development web server