### PR TITLE
New docker nodes, add ganesha NFS, update GPFS

### DIFF
--- a/ansible/idr-playbooks/idr-dundee-nfs.yml
+++ b/ansible/idr-playbooks/idr-dundee-nfs.yml
@@ -28,10 +28,10 @@
   - name: Mount NFS share
     become: yes
     mount:
-      fstype: nfs
+      fstype: nfs4
       name: "{{ idr_mountpoint }}"
       opts: rsize=8192,wsize=8192,timeo=14,intr,ro
-      src: idr-data.openmicroscopy.org:/uod/idr
+      src: idr-data.openmicroscopy.org:/idr
       state: mounted
     when: not use_samba
 

--- a/ansible/idrsystems-deployment.yml
+++ b/ansible/idrsystems-deployment.yml
@@ -6,5 +6,6 @@
 - include: idrsystems-playbooks/idr-gpfs-build.yml
 - include: idrsystems-playbooks/idr-gpfs-client.yml
 - include: idrsystems-playbooks/idr-nfs-hosts.yml
+- include: idrsystems-playbooks/idr-nfs-clients.yml
 - include: idrsystems-playbooks/idr-samba-hosts.yml
 - include: idrsystems-playbooks/idr-services.yml

--- a/ansible/idrsystems-playbooks/idr-docker-localstorage.yml
+++ b/ansible/idrsystems-playbooks/idr-docker-localstorage.yml
@@ -3,8 +3,6 @@
 
 - hosts: idr-docker-localstorage
   roles:
-  - role: server-swap
-  - role: network
   - role: lvm-partition
     lvm_lvname: root
     lvm_lvmount: /

--- a/ansible/idrsystems-playbooks/idr-gpfs-client.yml
+++ b/ansible/idrsystems-playbooks/idr-gpfs-client.yml
@@ -1,9 +1,7 @@
-# RPMs should already be built. You may need to update all packages and
-# reboot before running this
+# Install RPMs from a yum repo, compile and install kernel module
+# See roles/gpfs/README.md if you only have the original IBM Spectrum packages
 
 - hosts: idr-gpfs-client
   roles:
   - role: yum-excludes
   - role: gpfs
-    gpfs_install_check_kernel_version: False
-    gpfs_local_rpm_dir: ~/ansible-data/gpfs

--- a/ansible/idrsystems-playbooks/idr-nfs-clients.yml
+++ b/ansible/idrsystems-playbooks/idr-nfs-clients.yml
@@ -1,0 +1,6 @@
+---
+# Playbook for maintaining IDR NFS clients
+
+- hosts: idr-nfs-clients
+  roles:
+  - role: nfs-mount

--- a/ansible/idrsystems-playbooks/idr-nfs-hosts.yml
+++ b/ansible/idrsystems-playbooks/idr-nfs-hosts.yml
@@ -3,4 +3,4 @@
 
 - hosts: idr-nfs-hosts
   roles:
-  - role: nfs-share
+  - role: nfs-ganesha-share

--- a/ansible/idrsystems-playbooks/idr-upgrade.yml
+++ b/ansible/idrsystems-playbooks/idr-upgrade.yml
@@ -3,3 +3,4 @@
 - hosts: idr
   roles:
   - role: upgrade-distpackages
+    upgrade_distpackages_reboot_kernel: True

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -37,6 +37,7 @@ Optional variables:
 - `docker_lvopts`: Additional arguments to be used when creating logical volumes
 - `docker_groupmembers`: A list of users who will be added to the `docker` system group, allows docker to be run without sudo
 - `docker_use_ipv4_nic_mtu`: Force Docker to use the MTU set by the main IPV4 interface. This may be necessary on virtualised hosts, see comment in `defaults/main.yml`.
+- `docker_repo_version`: Use a different upstream Docker release branch e.g. `testing`, do not change this unless you know what you are doing
 
 
 Dependencies

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -23,3 +23,6 @@ docker_lvfilesystem: xfs
 # - https://github.com/docker/docker/issues/12565
 # TODO: Add an option to explicitly set the MTU in case auto-detection fails
 docker_use_ipv4_nic_mtu: False
+
+# Upstream Docker release branch
+docker_repo_version: main

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -65,5 +65,5 @@
     name: "{{ item }}"
     groups: docker
     append: yes
-  with_items: docker_groupmembers
+  with_items: "{{ docker_groupmembers }}"
   when: docker_groupmembers is defined

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -3,9 +3,9 @@
 
 - name: upstream docker | setup repository
   become: yes
-  copy:
-    src: docker.repo
-    dest: /etc/yum.repos.d/
+  template:
+    src: docker-repo.j2
+    dest: /etc/yum.repos.d/docker.repo
     backup: no
 
 - name: upstream docker | install docker

--- a/ansible/roles/docker/templates/docker-repo.j2
+++ b/ansible/roles/docker/templates/docker-repo.j2
@@ -1,6 +1,6 @@
 [dockerrepo]
 name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/7
+baseurl=https://yum.dockerproject.org/repo/{{ docker_repo_version }}/centos/7
 enabled=1
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg

--- a/ansible/roles/gpfs/defaults/main.yml
+++ b/ansible/roles/gpfs/defaults/main.yml
@@ -4,9 +4,15 @@
 # If true extract and build GPFS RPMs
 gpfs_build: False
 # If true install GPFS using RPMs
-gpfs_install: True
+gpfs_install: False
+# If true install GPFS from a yum repo and compile/install kernel module locally
+gpfs_repoinstall: True
 # If true configure system for GPFS
-gpfs_configure: gpfs_install
+gpfs_configure: gpfs_install or gpfs_repoinstall
+# URL to the base packages in a GPFS yum repository
+#gpfs_repo_url_base:
+# URL to the updates packages in a GPFS yum repository
+#gpfs_repo_url_updates:
 
 # Build/Install a GPFS module for this kernel version
 gpfs_kernel_version: 3.10.0-327.10.1.el7.x86_64

--- a/ansible/roles/gpfs/tasks/gpfs-configure.yml
+++ b/ansible/roles/gpfs/tasks/gpfs-configure.yml
@@ -45,7 +45,7 @@
     content: "{{ item.value }}"
     dest: /var/mmfs/etc/localMountOptions.{{ item.key }}
   when: item.value
-  with_dict: gpfs_node_specific_mount_options | default ({})
+  with_dict: "{{ gpfs_node_specific_mount_options | default ({}) }}"
 
 - name: gpfs | clear mount options
   become: yes
@@ -53,4 +53,4 @@
     path: /var/mmfs/etc/localMountOptions.{{ item.key }}
     state: absent
   when: not item.value
-  with_dict: gpfs_node_specific_mount_options | default ({})
+  with_dict: "{{ gpfs_node_specific_mount_options | default ({}) }}"

--- a/ansible/roles/gpfs/tasks/gpfs-repoinstall.yml
+++ b/ansible/roles/gpfs/tasks/gpfs-repoinstall.yml
@@ -1,0 +1,65 @@
+---
+# Install GPFS from an internal repo, compile and install kernel module
+
+- name: gpfs | setup repository
+  become: yes
+  template:
+    backup: no
+    dest: /etc/yum.repos.d/gpfs.repo
+    src: gpfs-repo.j2
+
+- name: gpfs | install kernel module build requirements
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - kernel-devel
+  - cpp
+  - gcc
+  - gcc-c++
+  - rpm-build
+  - kernel-headers
+
+- name: gpfs | install rpms
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - gpfs.base
+  - gpfs.docs
+  - gpfs.ext
+  - gpfs.gpl
+  - gpfs.gskit
+  - gpfs.msg.en_US
+
+# Autodetect the GPFS kernel and patch version
+
+- name: gpfs | current kernel version
+  command: uname -r
+  register: running_kernel_version
+  always_run: True
+
+- name: gpfs | latest installed gpfs.gpl
+  command: rpm -q gpfs.gpl --qf '%{VERSION}-%{RELEASE}'
+  register: gpfs_gpl_version
+  always_run: True
+
+- name: gpfs | expected kernel module rpm
+  set_fact:
+    gpfs_kernel_rpm: /root/rpmbuild/RPMS/x86_64/gpfs.gplbin-{{ running_kernel_version.stdout }}-{{ gpfs_gpl_version.stdout }}.x86_64.rpm
+
+- name: gpfs | build kernel module
+  become: yes
+  command: /usr/lpp/mmfs/bin/mmbuildgpl --buildrpm
+  args:
+    creates: "{{ gpfs_kernel_rpm }}"
+  environment:
+    LINUX_DISTRIBUTION: REDHAT_AS_LINUX
+
+- name: gpfs | install kernel module
+  become: yes
+  yum:
+    name: " {{ gpfs_kernel_rpm }}"
+    state: present

--- a/ansible/roles/gpfs/tasks/gpfs-repoinstall.yml
+++ b/ansible/roles/gpfs/tasks/gpfs-repoinstall.yml
@@ -40,11 +40,13 @@
   command: uname -r
   register: running_kernel_version
   always_run: True
+  changed_when: False
 
 - name: gpfs | latest installed gpfs.gpl
   command: rpm -q gpfs.gpl --qf '%{VERSION}-%{RELEASE}'
   register: gpfs_gpl_version
   always_run: True
+  changed_when: False
 
 - name: gpfs | expected kernel module rpm
   set_fact:

--- a/ansible/roles/gpfs/tasks/main.yml
+++ b/ansible/roles/gpfs/tasks/main.yml
@@ -5,12 +5,16 @@
 - name: gpfs | check gpfs_local_rpm_dir defined
   assert:
     that: gpfs_local_rpm_dir is defined and gpfs_local_rpm_dir
+  when: gpfs_build or gpfs_install
 
 - include: gpfs-build.yml
   when: gpfs_build
 
 - include: gpfs-install.yml
   when: gpfs_install
+
+- include: gpfs-repoinstall.yml
+  when: gpfs_repoinstall
 
 - include: gpfs-configure.yml
   when: gpfs_configure

--- a/ansible/roles/gpfs/templates/gpfs-repo.j2
+++ b/ansible/roles/gpfs/templates/gpfs-repo.j2
@@ -1,0 +1,15 @@
+# GPFS yum repository
+# Disabled by default since GPFS requires a compiled kernel module, upgraded
+# with care.
+
+[gpfs-base]
+name=GPFS Repository
+baseurl={{ gpfs_repo_url_base }}
+enabled=1
+gpgcheck=0
+
+[gpfs-updates]
+name=GPFS Repository
+baseurl={{ gpfs_repo_url_updates }}
+enabled=1
+gpgcheck=0

--- a/ansible/roles/nfs-ganesha-share/README.md
+++ b/ansible/roles/nfs-ganesha-share/README.md
@@ -1,0 +1,53 @@
+NFS Ganesha Share
+=================
+
+Manage NFS user mode (Ganesha) file shares (no authentication).
+
+Note if SELinux is enabled you may need modify the configure of the the shared directories (not handled by this role).
+
+
+Conflicts
+---------
+
+The NFS Ganesha server conflicts with the standard kernel NFS server, you can only run one.
+
+
+Role Variables
+--------------
+
+All variables are optional, though if `nfs_ganesha_shares` is unset the role is rather useless:
+- `nfs_ganesha_shares`: A list of dictionaries exports, hosts and options `{ path: /exported/directory, pseudopath: /pseudo/path (optional), fs: ganesha fs type (optional), clients: [{ host: host-cidr, access: RO|RW (optional), squash: None|Root|All (optional) }, ...] }`
+- `nfs_ganesha_default_log_level`: Change the default logging level
+
+The default options are `access: RO`, `squash: All`.
+Currently only the default of `fs: VFS` is supported by this role.
+For full details of configuration options see https://github.com/nfs-ganesha/nfs-ganesha/blob/master/src/config_samples/export.txt
+
+Note: during testing nfs-ganesha sometimes behaved inconsistently when processing the access rules in `/etc/ganesha/ganesha.conf`.
+I have no idea why.
+If you are trying to debug access problems note that at present (2016-07-21) the output of `showmount` may be incorrect.
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+      - role: nfs-ganesha-share
+        nfs_ganesha_shares:
+        - path: /srv/share1
+          pseudopath: /share1
+          clients:
+          - host: "192.168.1.0/25"
+        - path: /srv/share2
+          pseudopath: /share2
+          clients:
+          - host: "192.168.1.0/25, 172.16.0.0/20"
+            access: RW
+            squash: Root
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/nfs-ganesha-share/defaults/main.yml
+++ b/ansible/roles/nfs-ganesha-share/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for roles/nfs-gaensha-share
+
+# A list of shares, see README.md
+nfs_ganesha_shares: []
+
+# Logging level, leave unset for default
+nfs_ganesha_default_log_level:

--- a/ansible/roles/nfs-ganesha-share/handlers/main.yml
+++ b/ansible/roles/nfs-ganesha-share/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Handlers for nfs-ganesha-share
+
+- name: restart nfs-ganesha
+  become: yes
+  service:
+    name: nfs-ganesha
+    state: restarted

--- a/ansible/roles/nfs-ganesha-share/tasks/main.yml
+++ b/ansible/roles/nfs-ganesha-share/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# tasks file for roles/nfs-ganesha-share
+
+- name: system packages | install epel repo
+  become: yes
+  yum:
+    name: epel-release
+    state: present
+
+- name: nfs ganesha | install ganesha packages
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - nfs-ganesha
+  - nfs-ganesha-vfs
+
+- name: nfs ganesha | configure shares
+  become: yes
+  template:
+    backup: yes
+    dest: /etc/ganesha/ganesha.conf
+    src: ganesha-conf.j2
+  notify:
+    - restart nfs-ganesha
+
+- name: nfs ganesha | enable nfs-ganesha
+  become: yes
+  service:
+    enabled: yes
+    name: nfs-ganesha
+    state: started

--- a/ansible/roles/nfs-ganesha-share/templates/ganesha-conf.j2
+++ b/ansible/roles/nfs-ganesha-share/templates/ganesha-conf.j2
@@ -1,0 +1,37 @@
+# Managed by Ansible
+
+{% if nfs_ganesha_default_log_level %}
+LOG
+{
+    default_log_level = {{ nfs_ganesha_default_log_level }};
+}
+{% endif %}
+
+{% for item in nfs_ganesha_shares %}
+EXPORT
+{
+    # Export Id (mandatory, each EXPORT must have a unique Export_Id)
+    Export_Id = {{ loop.index }};
+
+    # Exported path (mandatory)
+    Path = {{ item.path }};
+
+    # Pseudo Path (required for NFS v4)
+    Pseudo = {{ item.pseudopath | default(item.path) }};
+
+    # Required for access (default is None)
+{%     for client in item.clients %}
+    CLIENT
+    {
+        Clients = {{ client.host }};
+        Access_Type = {{ client.access | default('RO') }};
+        Squash = {{ client.squash | default('All') }};
+    }
+{%     endfor %}
+
+    # Exporting FSAL
+    FSAL {
+        Name = {{ item.fs | default('VFS') }};
+    }
+}
+{% endfor %}

--- a/ansible/roles/nfs-mount/README.md
+++ b/ansible/roles/nfs-mount/README.md
@@ -1,0 +1,31 @@
+NFS Mount
+=========
+
+Manage NFS4 mounts.
+
+
+Role Variables
+--------------
+
+- `nfs_share_mounts`: List of dictionaries of NFS shares: `{ path: mount-point, mount: nfs server path, opts: mount options (optional) }`
+- `nfs_mount_opts`: Default NFS4 mount options
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+      - role: nfs-mount
+        nfs_share_mounts:
+        - path: /mnt/remote
+          location: nfs.example.org:/data
+        - path: /mnt/readonly
+          location: nfs.example.org:/read-only
+          opts: "{{ nfs_mount_opts }},ro"
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/nfs-mount/defaults/main.yml
+++ b/ansible/roles/nfs-mount/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for roles/nfs-mount
+
+# List of NFS shares
+nfs_share_mounts: []
+
+# Default NFS4 mount options
+nfs_mount_opts: rsize=8192,wsize=8192,timeo=14,intr

--- a/ansible/roles/nfs-mount/tasks/main.yml
+++ b/ansible/roles/nfs-mount/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# tasks file for roles/nfs-mount
+
+- name: Install NFS mount utility
+  become: yes
+  yum:
+    name: nfs-utils
+    state: present
+
+# Do not create mountpoint using file, the mount module will create it
+# automatically. This avoids problems where the module tries to change
+# permissions on an existing directory
+
+- name: Mount NFS share
+  become: yes
+  mount:
+    fstype: nfs4
+    name: "{{ item.path }}"
+    opts: "{{ item.opts | default(nfs_mount_opts) }}"
+    src: "{{ item.location }}"
+    state: mounted
+  with_items: nfs_share_mounts

--- a/ansible/roles/nfs-mount/tasks/main.yml
+++ b/ansible/roles/nfs-mount/tasks/main.yml
@@ -19,4 +19,4 @@
     opts: "{{ item.opts | default(nfs_mount_opts) }}"
     src: "{{ item.location }}"
     state: mounted
-  with_items: nfs_share_mounts
+  with_items: "{{ nfs_share_mounts }}"

--- a/ansible/roles/upgrade-distpackages/README.md
+++ b/ansible/roles/upgrade-distpackages/README.md
@@ -2,6 +2,7 @@ Upgrade Distribution packages
 =============================
 
 Upgrades all packages installed with the distribution's package manager.
+Optionally reboots the system if a kernel update was found.
 
 
 Role Variables
@@ -10,6 +11,8 @@ Role Variables
 Optional variables:
 
 - `upgrade_distpackages`: List of packages to upgrade (default: all)
+- `upgrade_distpackages_reboot_kernel`: Automatically reboot if a new kernel is installed (default `False`)
+- `upgrade_distpackages_reboot_timeout`: Maximum time to wait for a reboot (default `600` seconds)
 
 
 Author Information

--- a/ansible/roles/upgrade-distpackages/defaults/main.yml
+++ b/ansible/roles/upgrade-distpackages/defaults/main.yml
@@ -3,3 +3,9 @@
 
 # List of packages to upgrade
 upgrade_distpackages: "*"
+
+# Automatically reboot if running kernel is different from the latest installed?
+upgrade_distpackages_reboot_kernel: False
+
+# Maximum time to wait for a reboot
+upgrade_distpackages_reboot_timeout: 600

--- a/ansible/roles/upgrade-distpackages/tasks/main.yml
+++ b/ansible/roles/upgrade-distpackages/tasks/main.yml
@@ -12,12 +12,14 @@
   command: uname -r
   register: running_kernel_version
   always_run: True
+  changed_when: False
 
 # http://serverfault.com/a/601432
 - name: system | latest installed kernel
   shell: rpm -q kernel --qf '%{BUILDTIME} %{VERSION}-%{RELEASE}.%{ARCH}\n' | tail -n 1 | cut -f 2 -d ' '
   register: latest_kernel_version
   always_run: True
+  changed_when: False
 
 - name: system | check if reboot needed
   set_fact:

--- a/ansible/roles/upgrade-distpackages/tasks/main.yml
+++ b/ansible/roles/upgrade-distpackages/tasks/main.yml
@@ -7,3 +7,41 @@
     name: "{{ item }}"
     state: latest
   with_items: "{{ upgrade_distpackages }}"
+
+- name: system | current running kernel
+  command: uname -r
+  register: running_kernel_version
+  always_run: True
+
+# http://serverfault.com/a/601432
+- name: system | latest installed kernel
+  shell: rpm -q kernel --qf '%{BUILDTIME} %{VERSION}-%{RELEASE}.%{ARCH}\n' | tail -n 1 | cut -f 2 -d ' '
+  register: latest_kernel_version
+  always_run: True
+
+- name: system | check if reboot needed
+  set_fact:
+    system_reboot_needed: "{{ running_kernel_version.stdout != latest_kernel_version.stdout }}"
+
+- debug:
+    msg: "Reboot needed (kernel): Current:{{ running_kernel_version.stdout }} Latest:{{ latest_kernel_version.stdout }}"
+  when: system_reboot_needed
+
+# https://support.ansible.com/hc/en-us/articles/201958037-Reboot-a-server-and-wait-for-it-to-come-back
+- name: system | reboot
+  become: yes
+  shell: "sleep 2 && shutdown -r now 'Rebooting (Ansible kernel update)'"
+  async: 1
+  poll: 0
+  ignore_errors: True
+  when: upgrade_distpackages_reboot_kernel and system_reboot_needed
+
+- name: system | wait for server to reboot
+  local_action:
+    module: wait_for
+    delay: 15
+    host: "{{ ansible_host | default(inventory_hostname) }}"
+    port: "{{ ansible_port | default(22) }}"
+    state: "started"
+    timeout: "{{ upgrade_distpackages_reboot_timeout }}"
+  when: upgrade_distpackages_reboot_kernel and system_reboot_needed


### PR DESCRIPTION
Multiple changes related to setting up some new servers, and re-imaging the broken GPFS/NFS server.

## `roles/docker`
- Option added to use a different repo, e.g. `testing` to install docker release candidates
- Fixed variable quoting warning

## `roles/gpfs`
- Added a simpler alternative to the current build and install steps. If you have access to a GPFS yum repository, and you don't mind installing a compiler tool-chain on your server, you can install the base RPMs from the repo, compile the kernel module on the server, and install it

## `roles/nfs-ganesha-share`
- The `nfs-share` role uses the built-in kernel NFS server, however this has problems when serving GPFS: https://access.redhat.com/solutions/1553943. nfs-ganesha is a user-mode server which may work better.
- Note that this is the default `VFS` module, not the specialised `GPFS` nfs-ganesha module which is probably more efficient and reliable. This will be investigated in future.

## `roles/upgrade-distpackages`
- I tried to optionally have the role reboot the computer following a kernel upgrade. This works with VMs but may not work with physical servers where it takes longer than the initial delay (15s) to shutdown.

## `roles/nfs-mount`
- Mounts a list of NFS shares, this is easier than writing multiple `tasks:mount` in a playbook