### PR TITLE
Add gpfs symlinks, Add sudoers

### DIFF
--- a/ansible/idrsystems-deployment.yml
+++ b/ansible/idrsystems-deployment.yml
@@ -5,6 +5,7 @@
 - include: idrsystems-playbooks/idr-docker-localstorage.yml
 - include: idrsystems-playbooks/idr-gpfs-build.yml
 - include: idrsystems-playbooks/idr-gpfs-client.yml
+- include: idrsystems-playbooks/idr-gpfs-scratch.yml
 - include: idrsystems-playbooks/idr-nfs-hosts.yml
 - include: idrsystems-playbooks/idr-nfs-clients.yml
 - include: idrsystems-playbooks/idr-samba-hosts.yml

--- a/ansible/idrsystems-playbooks/idr-docker-localstorage.yml
+++ b/ansible/idrsystems-playbooks/idr-docker-localstorage.yml
@@ -21,4 +21,5 @@
   - role: basedeps
   - role: logrotate
   - role: docker
+  - role: sudoers
   - role: versioncontrol-utils

--- a/ansible/idrsystems-playbooks/idr-gpfs-scratch.yml
+++ b/ansible/idrsystems-playbooks/idr-gpfs-scratch.yml
@@ -1,0 +1,12 @@
+# Symlink GPFS directories
+
+- hosts: idr-gpfs-scratch
+  tasks:
+  - name: Symlink directory
+    become: yes
+    file:
+      force: yes
+      path: "{{ item.value }}"
+      src: "{{ item.key }}"
+      state: link
+    with_dict: "{{ idr_gpfs_scratch_symlinks }}"


### PR DESCRIPTION
In conjunction with the private config file this:
- symlinks `/home/idr-scratch` into gpfs. The intention is to make it clearer that the main gpfs directory can be mounted read-only in docker and to have `/home/idr-scratch` mounted in docker read-write.
- adds the `sudoers` role. This requires an additional configuration file to have an effect, and could arguably go into a common-top-level playbook for all servers.