### PR TITLE
Rename idr-docker-localstorage to idr-docker

### DIFF
--- a/ansible/idrsystems-deployment.yml
+++ b/ansible/idrsystems-deployment.yml
@@ -2,7 +2,7 @@
 # Playbook for running all IDR deployment playbooks
 
 - include: idrsystems-playbooks/idr-analysis.yml
-- include: idrsystems-playbooks/idr-docker-localstorage.yml
+- include: idrsystems-playbooks/idr-docker.yml
 - include: idrsystems-playbooks/idr-gpfs-build.yml
 - include: idrsystems-playbooks/idr-gpfs-client.yml
 - include: idrsystems-playbooks/idr-gpfs-scratch.yml

--- a/ansible/idrsystems-playbooks/idr-docker.yml
+++ b/ansible/idrsystems-playbooks/idr-docker.yml
@@ -1,7 +1,7 @@
 ---
 # Playbook for provisioning IDR Docker nodes with local docker storage
 
-- hosts: idr-docker-localstorage
+- hosts: idr-docker
   roles:
   - role: lvm-partition
     lvm_lvname: root


### PR DESCRIPTION
I need to split up the configuration of the `idr-docker-localstorage` group into two (the same variable needs to take different values on different nodes), and now that the old docker nodes have been re-imaged it's a good time to rename this group to just `idr-docker`