### PR TITLE
pip install the latest ice 3.6.x

### DIFF
--- a/ansible/roles/ice/tasks/main.yml
+++ b/ansible/roles/ice/tasks/main.yml
@@ -35,8 +35,7 @@
 - name: zeroc ice | pip install packages
   become: yes
   pip:
-    name: "{{ item.name }}"
+    name: "{{ item }}"
     state: present
-    version: "{{ item.version }}"
   with_items: "{{ ice_pip_packages }}"
   when: ice_pip_packages

--- a/ansible/roles/ice/vars/ice-3.6.yml
+++ b/ansible/roles/ice/vars/ice-3.6.yml
@@ -15,6 +15,5 @@ ice_pip_dependencies:
   - python-devel
   - python-pip
 ice_pip_packages:
-  - name: zeroc-ice
   # We want the highest minor release
-    version: 3.6.1
+  - "zeroc-ice>=3.6,<3.7"


### PR DESCRIPTION
Previously this would pip-install `ice 3.6.1`. It should now install the most recent in the `3.6` series.