### PR TITLE
Omero server cleanups

### DIFF
--- a/ansible/roles/omero-server/README.md
+++ b/ansible/roles/omero-server/README.md
@@ -26,6 +26,7 @@ This defaults to `latest`, but due to the broken registry a proper upgrade check
 You are advised to change this to an actual release version.
 - `postgresql_users_databases`: Used by the `postgres` role, if the PostgreSQL server is on the same node as the OMERO.server define this variable to create the local databases and users.
 If a remote database server is used a user and empty database must already exist.
+- `ice_version`: This variable originates from the `ice` role, leave unset for the default.
 
 
 Warning

--- a/ansible/roles/omero-server/README.md
+++ b/ansible/roles/omero-server/README.md
@@ -21,7 +21,7 @@ Role Variables
 
 All variables are optional, see `defaults/main.yml` for the full list
 
-- `release`: The OMERO release, e.g. `5.2.2`.
+- `omero_release`: The OMERO release, e.g. `5.2.2`.
 This defaults to `latest`, but due to the broken registry a proper upgrade check has not been implemented so this will not have the expected effect (it will always attempt to upgrade even if the current server is the latest).
 You are advised to change this to an actual release version.
 - `postgresql_users_databases`: Used by the `postgres` role, if the PostgreSQL server is on the same node as the OMERO.server define this variable to create the local databases and users.
@@ -48,16 +48,16 @@ Example Playbooks
           password: omero
           databases: [omero]
 
-      # Install or upgrade to a particular version, use an external database
-      - hosts: localhost
-        roles:
-        - omero-server
-          omero_upgrade: True
-          release: 5.2.2
-          omero_dbhost: postgres.example.org
-          omero_dbuser: db_user
-          omero_dbname: db_name
-          omero_dbpassword: db_password
+    # Install or upgrade to a particular version, use an external database
+    - hosts: localhost
+      roles:
+      - omero-server
+        omero_upgrade: True
+        omero_release: 5.2.2
+        omero_dbhost: postgres.example.org
+        omero_dbuser: db_user
+        omero_dbname: db_name
+        omero_dbpassword: db_password
 
 
 Author Information

--- a/ansible/roles/omero-server/tasks/main.yml
+++ b/ansible/roles/omero-server/tasks/main.yml
@@ -137,7 +137,7 @@
 - name: omero | checkupgrade
   set_fact:
     omero_update_needed: True
-  when: (omero_server_version.stdout | regex_replace('^([^-]+).*', '\\1')) != omero_release
+  when: omero_server_symlink_st.stat.exists and (omero_server_version.stdout | regex_replace('^([^-]+).*', '\\1')) != omero_release
   ignore_errors: yes
 
 - name: omero | checkupgrade

--- a/ansible/roles/omero-server/tasks/main.yml
+++ b/ansible/roles/omero-server/tasks/main.yml
@@ -3,6 +3,11 @@
 
 - include: ansible-prerequisites.yml
 
+# Include this first so that the omero system user gets created with the
+# correct home directory skeleton since if the home directory already exists
+# it won't be modified
+- include: omero-user.yml
+
 - include: omego.yml
 
 - name: omero | is server symlink present
@@ -10,69 +15,6 @@
   stat:
     path: "{{ omero_serverdir }}/{{ omero_server_symlink }}"
   register: omero_server_symlink_st
-
-- name: omero | create system user
-  become: yes
-  user:
-    name: "{{ omero_system_user }}"
-    home: "{{ omero_basedir }}"
-    append: yes
-    state: present
-    #system: yes
-    shell: /bin/bash
-    uid: "{{ omero_system_uid | default(omit) }}"
-
-# Explicitly include omero_basedir so that it'll be world-accessible
-- name: omero | create omero directories
-  become: yes
-  file:
-    mode: 0755
-    path: "{{ item }}"
-    state: directory
-    serole: _default
-    setype: _default
-    seuser: _default
-  with_items:
-    - "{{ omero_basedir }}"
-    - "{{ omero_basedir }}/config"
-    - "{{ omero_serverdir }}"
-
-- name: omero | copy bash skeleton files
-  become: yes
-  copy:
-    src: "/etc/skel/{{ item }}"
-    dest: "{{ omero_basedir }}"
-    owner: "omero"
-    group: "omero"
-    remote_src: True
-  with_items:
-    - .bashrc
-    - .bash_profile
-    - .bash_logout
-
-- name: omero | add to path
-  become: yes
-  lineinfile:
-    dest: "{{ omero_basedir }}/.bashrc"
-    regexp: "{{ omero_server_symlink }}"
-    line: "export PATH={{ omero_serverdir }}/{{ omero_server_symlink }}/bin:$PATH"
-    state: present
-
-- name: omero | set JAVA_OPTS
-  become: yes
-  lineinfile:
-    dest: "{{ omero_basedir }}/.bashrc"
-    regexp: "JAVA_OPTS"
-    line: "export JAVA_OPTS=-Xmx2G"
-    state: present
-
-- name: omero | set owner omero server directory
-  become: yes
-  file:
-    owner: "{{ omero_system_user }}"
-    path: "{{ omero_serverdir }}"
-    state: directory
-
 
 # OMERO data directory: If it already exists assume the permissions are
 # correct, don't touch anything

--- a/ansible/roles/omero-server/tasks/main.yml
+++ b/ansible/roles/omero-server/tasks/main.yml
@@ -96,6 +96,7 @@
       --sym {{ omero_server_symlink }}
       --prestartfile {{ omero_basedir }}/config/omero-base.config
       --prestartfile {{ omero_basedir }}/config/omero-additional.config
+      --ice {{ ice_version }}
       {{ omero_omego_verbosity }}
       {{ omero_omego_additional_args }}
       {{ omero_systemd_setup | ternary('--no-start', '') }}

--- a/ansible/roles/omero-server/tasks/omero-user.yml
+++ b/ansible/roles/omero-server/tasks/omero-user.yml
@@ -1,0 +1,51 @@
+---
+# Setup omero system user
+
+- name: omero | create system user
+  become: yes
+  user:
+    name: "{{ omero_system_user }}"
+    home: "{{ omero_basedir }}"
+    append: yes
+    state: present
+    #system: yes
+    shell: /bin/bash
+    uid: "{{ omero_system_uid | default(omit) }}"
+
+# Explicitly include omero_basedir so that it'll be world-accessible
+- name: omero | create omero directories
+  become: yes
+  file:
+    mode: 0755
+    path: "{{ item }}"
+    state: directory
+    serole: _default
+    setype: _default
+    seuser: _default
+  with_items:
+    - "{{ omero_basedir }}"
+    - "{{ omero_basedir }}/config"
+    - "{{ omero_serverdir }}"
+
+- name: omero | add to path
+  become: yes
+  lineinfile:
+    dest: "{{ omero_basedir }}/.bashrc"
+    regexp: "{{ omero_server_symlink }}"
+    line: "export PATH={{ omero_serverdir }}/{{ omero_server_symlink }}/bin:$PATH"
+    state: present
+
+- name: omero | set JAVA_OPTS
+  become: yes
+  lineinfile:
+    dest: "{{ omero_basedir }}/.bashrc"
+    regexp: "JAVA_OPTS"
+    line: "export JAVA_OPTS=-Xmx2G"
+    state: present
+
+- name: omero | set owner omero server directory
+  become: yes
+  file:
+    owner: "{{ omero_system_user }}"
+    path: "{{ omero_serverdir }}"
+    state: directory

--- a/ansible/training-server.yml
+++ b/ansible/training-server.yml
@@ -11,9 +11,6 @@
     # Taking this from the openstack playbook os-omero.yml, to install the systemd config.
     omero_systemd_setup: True
 
-    # Variable to tell OMEGO to get Ice 3.5, not the 'latest ice'. Ice role doesn't install latest at the moment, but Ice 3.5.
-    omero_omego_additional_args: "--ice 3.5"
-
   vars:
   - postgresql_users_databases:
     - user: omero


### PR DESCRIPTION
- Fixes the lack of idempotency when modifying `~omero/.bashrc`: closes https://github.com/openmicroscopy/infrastructure/issues/77
- The `omero-server` role takes into account the value of `ice_version` from `roles/ice` (currently still `3.5`, should it be bumped to `3.6`?)
- Remove a harmless (though distracting) red ignored error message when checking for the existing version of a non-existent server
- `training-server.yml` updated to take account of the above