### PR TITLE
improve ci deployment

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -10,3 +10,4 @@
 
 [defaults]
 roles_path = roles/
+retry_files_enabled = False

--- a/ansible/ci-deployment.yml
+++ b/ansible/ci-deployment.yml
@@ -24,9 +24,6 @@
         password: omero
         databases: [omero]
       postgresql_server_chown_datadir: True
-  vars:
-    - javajdkversions:
-      - 1.8.0
 
 # Deploy OMERO build and runtime prerequisites
 - hosts: ci-omero-web
@@ -34,11 +31,6 @@
     - role: omero-runtime
     - role: omero-web-runtime
     - role: nginx
-  vars:
-    - omero_selinux_setup: True
-    - omero_web_runtime_redis: True
-    - javajdkversions:
-      - 1.8.0
 
 # Deploy Documentation prerequisites
 - hosts: ci-docs

--- a/ansible/ci-deployment.yml
+++ b/ansible/ci-deployment.yml
@@ -4,6 +4,7 @@
 - hosts: ci-jenkins-linux
   roles:
     - role: jenkinsslave
+    - role: sudoers
     - role: versioncontrol-utils
 
 # Deploy OMERO build and runtime prerequisites
@@ -11,10 +12,31 @@
   roles:
     - role: omero-build
     - role: omero-runtime
-    - role: omero-build-cpp
+#    - role: omero-build-cpp
     - role: postgresql
+      postgresql_server_listen: "'*'"
+      postgresql_server_auth:
+      - database: all
+        user: omero
+        address: 0.0.0.0/0
+      postgresql_users_databases:
+      - user: omero
+        password: omero
+        databases: [omero]
+      postgresql_server_chown_datadir: True
+  vars:
+    - javajdkversions:
+      - 1.8.0
+
+# Deploy OMERO build and runtime prerequisites
+- hosts: ci-omero-web
+  roles:
+    - role: omero-runtime
+    - role: omero-web-runtime
     - role: nginx
   vars:
+    - omero_selinux_setup: True
+    - omero_web_runtime_redis: True
     - javajdkversions:
       - 1.8.0
 

--- a/ansible/inventory/README.md
+++ b/ansible/inventory/README.md
@@ -1,0 +1,4 @@
+This directory is useful for testing against openstack, but
+likely you will want to have a copy of these files in your
+own inventory directory with group_vars and host_vars as
+needed.

--- a/ansible/os-uod-docker.yml
+++ b/ansible/os-uod-docker.yml
@@ -10,7 +10,7 @@
 
   vars:
 
-    vm_image: "CentOS 7 1604"
+    vm_image: "CentOS 7 1607"
     vm_flavour: m2.large
     vm_groups: "ansible-managed,os-image-centos,docker-hosts"
     ignore_internal_known_hosts: True

--- a/ansible/os-uod-slave.yml
+++ b/ansible/os-uod-slave.yml
@@ -1,0 +1,27 @@
+---
+# Playbook for starting a Jenkins slave in the UoD
+# openstack cloud.
+#
+# Usage:
+#   $ source openrc.sh
+#   $ ansible-playbook -i {inventory_dir} os-uod-slave.yml -e vm_name=web-server
+#   $ ansible-playbook -i {inventory_dir} uod-slave.yml -l web-server
+
+# Re-using the docker playbook so that we have the option
+# of starting docker services as a part of a Jenkins job.
+- include: os-uod-docker.yml
+  vars:
+      vm_groups: "ansible-managed,os-image-centos,docker-hosts,ci-jenkins-linux,ci-omero,ci-omero-web"
+      vm_key_name: "jenkins"
+      # We're hard-coding the key since it must match the rest of the
+      # jenkins infrastructure.
+
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+  - role: openstack-volume-storage
+    openstack_volume_size: 100
+    openstack_volume_vmname: "{{ vm_name }}"
+    openstack_volume_name: opthudson
+    openstack_volume_device: /dev/vdb

--- a/ansible/roles/basedeps/tasks/main.yml
+++ b/ansible/roles/basedeps/tasks/main.yml
@@ -20,3 +20,4 @@
     - unzip
     - wget
     - zip
+    - gcc

--- a/ansible/roles/ice/vars/ice-3.6.yml
+++ b/ansible/roles/ice/vars/ice-3.6.yml
@@ -10,7 +10,9 @@ ice_devel_packages:
 ice_pip_dependencies:
   - gcc
   - gcc-c++
+  - libdb-utils
   - bzip2-devel
+  - expat-devel
   - openssl-devel
   - python-devel
   - python-pip

--- a/ansible/roles/jenkinsslave/defaults/main.yml
+++ b/ansible/roles/jenkinsslave/defaults/main.yml
@@ -4,6 +4,7 @@
 jenkinsuser: hudson
 jenkinsworkdir: /opt/hudson
 authorized_key: "ssh-rsa KEY"
+snoopy_dir_path:
 gitconfig:
   user: email@example.org
   name: Firstname Lastname

--- a/ansible/roles/jenkinsslave/meta/main.yml
+++ b/ansible/roles/jenkinsslave/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
 - { role: java }
+- { role: basedeps }

--- a/ansible/roles/jenkinsslave/tasks/main.yml
+++ b/ansible/roles/jenkinsslave/tasks/main.yml
@@ -14,6 +14,10 @@
     state: directory
     owner: "{{ jenkinsuser }}"
     group: "{{ jenkinsuser }}"
+    mode: "0755"
+    serole: "_default"
+    setype: "_default"
+    seuser: "_default"
 
 - name: jenkins | ssh key
   become: yes

--- a/ansible/roles/jenkinsslave/tasks/main.yml
+++ b/ansible/roles/jenkinsslave/tasks/main.yml
@@ -21,6 +21,36 @@
     user: "{{ jenkinsuser }}"
     key: "{{ authorized_key }}"
 
+- name: copy snoopy keys
+  become: yes
+  become_user: "{{ jenkinsuser }}"
+  copy:
+    src={{ snoopy_dir_path }}/{{ item.srcfile }}
+    dest=/home/{{ jenkinsuser }}/{{ item.dest }}
+    owner={{ jenkinsuser }}
+    group={{ jenkinsuser }}
+    mode=0700
+  with_items:
+    - { srcfile: ".ssh/config", dest: ".ssh/config" }
+    - { srcfile: ".ssh/snoopycrimecop_github", dest: ".ssh/snoopycrimecop_github" }
+    - { srcfile: ".ssh/snoopycrimecop_github.pub", dest: ".ssh/snoopycrimecop_github.pub" }
+    - { srcfile: ".gitconfig", dest: ".gitconfig" }
+  when: not spacewalk and snoopy_dir_path|length>0
+
+- name: generate known_hosts
+  become: yes
+  become_user: "{{ jenkinsuser }}"
+  shell: ssh-keyscan github.com >> /home/{{ jenkinsuser }}/.ssh/known_hosts
+  when: not spacewalk and snoopy_dir_path|length>0
+
+- name: chmod known_hosts
+  become: yes
+  become_user: "{{ jenkinsuser }}"
+  file:
+    path=/home/{{ jenkinsuser }}/.ssh/known_hosts
+    mode=0700
+  when: not spacewalk and snoopy_dir_path|length>0
+
 - name: jenkins | ssh access
   become: yes
   lineinfile:

--- a/ansible/roles/jenkinsslave/tasks/main.yml
+++ b/ansible/roles/jenkinsslave/tasks/main.yml
@@ -30,6 +30,26 @@
     insertbefore: "-:ALL EXCEPT root:ALL"
   when: not spacewalk
 
+- name: jenkins | sudo passwordless
+  become: yes
+  lineinfile:
+    dest: /etc/sudoers
+    backup: yes
+    line: "{{ jenkinsuser }}    ALL=(omero:omero)    NOPASSWD: ALL"
+    insertafter: "^## Same thing without a password"
+    state: present
+    validate: 'visudo -cf %s'
+  when: not spacewalk
+
+- name: "jenkins | fix sudo: sorry, you must have a tty to run sudo"
+  become: yes
+  replace:
+    dest: /etc/sudoers
+    regexp: '^Defaults    requiretty'
+    replace: 'Defaults:{{ jenkinsuser }} !requiretty'
+    backup: yes
+  when: not spacewalk
+
 - name: jenkins | git config
   become: yes
   template:

--- a/ansible/roles/jenkinsslave/tasks/main.yml
+++ b/ansible/roles/jenkinsslave/tasks/main.yml
@@ -31,10 +31,9 @@
     group={{ jenkinsuser }}
     mode=0700
   with_items:
-    - { srcfile: ".ssh/config", dest: ".ssh/config" }
-    - { srcfile: ".ssh/snoopycrimecop_github", dest: ".ssh/snoopycrimecop_github" }
-    - { srcfile: ".ssh/snoopycrimecop_github.pub", dest: ".ssh/snoopycrimecop_github.pub" }
-    - { srcfile: ".gitconfig", dest: ".gitconfig" }
+    - { srcfile: "config", dest: ".ssh/config" }
+    - { srcfile: "snoopycrimecop_github", dest: ".ssh/snoopycrimecop_github" }
+    - { srcfile: "snoopycrimecop_github.pub", dest: ".ssh/snoopycrimecop_github.pub" }
   when: not spacewalk and snoopy_dir_path|length>0
 
 - name: generate known_hosts

--- a/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
+++ b/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
@@ -20,6 +20,8 @@
       state: present
   with_items:
     - scc
-    - sphinx
+    - omego
+    - genshi yaclifw pytest PyYAML
+    - Sphinx==1.2.3 epydoc
     - "django>=1.8,<1.9"
 

--- a/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
+++ b/ansible/roles/jenkinsslave/tasks/setup_virtualenv.yml
@@ -8,10 +8,18 @@
   with_items:
     - python-pip
     - python-virtualenv
-    
-- name: virtualenv | scc
+
+- name: install python packages
   become: yes
   become_user: "{{ jenkinsuser }}"
   pip:
-    virtualenv: /home/{{ jenkinsuser }}/virtualenv
-    name: scc
+      name: "{{ item }}"
+      virtualenv: "/home/{{ jenkinsuser }}/virtualenv"
+      virtualenv_command: "virtualenv"
+      virtualenv_site_packages: "yes"
+      state: present
+  with_items:
+    - scc
+    - sphinx
+    - "django>=1.8,<1.9"
+

--- a/ansible/roles/omero-runtime/tasks/main.yml
+++ b/ansible/roles/omero-runtime/tasks/main.yml
@@ -9,8 +9,25 @@
   with_items:
     - Cython
     - numpy
-    - python-pillow
     - python-matplotlib
     - python-numexpr
     - python-tables
+    - python-pip
     - scipy
+
+# Uninstall python module rpms that will be replaced with a pip installed version
+- name: omero | remove python packages
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - python-pillow
+
+- name: omero | pip install packages
+  become: yes
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "Pillow==2.9"

--- a/ansible/roles/omero-web-runtime/defaults/main.yml
+++ b/ansible/roles/omero-web-runtime/defaults/main.yml
@@ -3,3 +3,4 @@
 
 # Whether to install redis requirements
 omero_web_runtime_redis: False
+omero_selinux_setup: False

--- a/ansible/roles/omero-web-runtime/tasks/main.yml
+++ b/ansible/roles/omero-web-runtime/tasks/main.yml
@@ -41,3 +41,33 @@
     name: "django-redis-cache>=1.6.5"
     state: present
   when: omero_web_runtime_redis
+
+
+# selinux
+- name: omero | install selinux utilities
+  become: yes
+  yum:
+    name: libselinux-python
+    state: present
+  when: omero_selinux_setup
+
+- name: omero web | selinux booleans
+  become: yes
+  seboolean:
+    name: "{{ item }}"
+    state: yes
+    persistent: yes
+  with_items:
+    - httpd_read_user_content
+    - httpd_enable_homedirs
+  when: omero_selinux_setup
+
+# Alternatively set httpd_can_network_connect=yes to allow all ports
+- name: omero web | selinux ports
+  become: yes
+  seport:
+    ports: "4080"
+    proto: tcp
+    setype: http_port_t
+    state: present
+  when: omero_selinux_setup

--- a/ansible/roles/omero-web-runtime/tasks/main.yml
+++ b/ansible/roles/omero-web-runtime/tasks/main.yml
@@ -8,7 +8,6 @@
     state: present
   with_items:
     - python-pip
-    - python-pillow
 
 - name: omero web | install python redis package
   become: yes
@@ -25,6 +24,7 @@
     state: absent
   with_items:
     - python-gunicorn
+    - python-pillow
 
 - name: omero web | pip install packages
   become: yes
@@ -32,6 +32,7 @@
     name: "{{ item }}"
     state: present
   with_items:
+    - "Pillow==2.9"
     - "django>=1.8,<1.9"
     - "gunicorn>=19.3"
 

--- a/ansible/roles/postgresql/tasks/databases.yml
+++ b/ansible/roles/postgresql/tasks/databases.yml
@@ -29,6 +29,7 @@
     encrypted: yes
     name: "{{ item.0.user }}"
     password: "{{ item.0.password }}"
+    role_attr_flags: "CREATEDB,NOSUPERUSER"
     state: present
   with_subelements:
     - "{{ postgresql_users_databases }}"

--- a/ansible/uod-slave.yml
+++ b/ansible/uod-slave.yml
@@ -1,0 +1,16 @@
+---
+# Playbook for managing a Jenkins slave in the
+# openstack cloud.
+
+- include: os-uod-docker.yml
+
+# Duplicate of part of uod-docker.yml for the /opt/hudson directory
+- hosts: ci-jenkins-linux
+  vars:
+    ansible_user: centos
+  roles:
+  - role: storage-volume-initialise
+    storage_volume_initialise_device: /dev/vdc
+    storage_volume_initialise_mount: /opt/hudson
+
+- include: ci-deployment.yml


### PR DESCRIPTION
This PR improve ci slave deployment:
 - add epel repo
 - add hudson to sudoers
 - add omero postgres user and allow creating DB


# To test: first clone https://github.com/openmicroscopy/management_tools/pull/181
- define `management_tools/ansible/ci/ci-test-hosts`:

 ```
# Jenkins CI slave nodes
[ci-jenkins-linux]
ip1 (server)
ip2 (web)

[ci-omero]
ip1

[ci-omero-web]
ip2
```
- clone this
- cd infrastructure/ansible

- run playbook

 ```
ansible-playbook -i ../../management_tools/ansible/ci/ci-test-hosts  -vv -u centos ci-deployment.yml
```

Jenkins authorized key is set in https://github.com/openmicroscopy/management_tools/blob/master/ansible/ci/group_vars/ci-jenkins-linux#L8. make sure appropriate `SSH Username with private key` is chosen to Jenkins before connecting to the node.

see http://10.0.51.148/


Todo:
- no strategy for storing snoopy ssh keys

