### PR TITLE
devspace playbook

### DIFF
--- a/ansible/devspace-runtime.yml
+++ b/ansible/devspace-runtime.yml
@@ -1,0 +1,36 @@
+- name: Run devspace
+  hosts: devspace
+  connection: ssh
+  gather_facts: no
+  become_user: "{{ devuser }}"
+
+  environment:
+    USER_ID: "{{ user_id }}"
+
+  tasks:
+    - name: Devspace down
+      docker_service:
+        project_src: "{{ devhome }}"
+        state: absent
+    - name: Devspace up
+      docker_service:
+        project_src: "{{ devhome }}"
+        state: present
+
+      register: output
+
+    - debug: var=output
+
+    - assert:
+        that:
+        - "jenkins.devspace_jenkins_1.state.running"
+        - "pg.devspace_pg_1.state.running"
+        - "testintegration.devspace_testintegration_1.state.running"
+        - "omero.devspace_omero_1.state.running"
+        - "web.devspace_web_1.state.running"
+        - "nginx.devspace_nginx_1.state.running"
+        - "nginxjenkins.devspace_nginxjenkins_1.state.running"
+        - "redis.devspace_redis_1.state.running"
+        - "seleniumhub.devspace_seleniumhub_1.state.running"
+        - "seleniumfirefox.devspace_seleniumfirefox_1.state.running"
+        - "seleniumchrome.devspace_seleniumchrome_1.state.running"

--- a/ansible/devspace.yml
+++ b/ansible/devspace.yml
@@ -1,0 +1,10 @@
+---
+# Playbook for provisioning Devspace
+
+- hosts: devspace
+
+  roles:
+    - role: upgrade-distpackages
+    - role: docker
+    - role: versioncontrol-utils
+    - role: devspace

--- a/ansible/os-devspace.yml
+++ b/ansible/os-devspace.yml
@@ -17,6 +17,7 @@
     vm_image: "CentOS 7 1607"
     vm_key_name: "jenkins"
     vm_flavour: m2.large
+    vm_size: 50
     vm_groups: "ansible-managed,os-image-centos,docker-hosts,devspace"
     ignore_internal_known_hosts: True
 
@@ -64,6 +65,9 @@
         name: "{{ vm_name }}"
         state: present
         image: "{{ vm_image }}"
+        boot_from_volume: True
+        volume_size: "{{ vm_size }}"
+        terminate_volume: true
         key_name: "{{ vm_key_name }}"
         flavor: "{{ vm_flavour }}"
         auto_ip: yes

--- a/ansible/os-devspace.yml
+++ b/ansible/os-devspace.yml
@@ -1,0 +1,88 @@
+---
+# Playbook for starting a docker instance in the
+# openstack cloud.
+
+## See os-create.yml
+
+## Run:
+# $ source openrc.sh
+# $ ansible-playbook os-devspace.yml -e vm_name=test-devspace -e vm_key_name=yourprofile
+
+- hosts: localhost
+  connection: local
+  #gather_facts: false
+
+  vars:
+
+    vm_image: "CentOS 7 1607"
+    vm_key_name: "jenkins"
+    vm_flavour: m2.large
+    vm_groups: "ansible-managed,os-image-centos,docker-hosts,devspace"
+    ignore_internal_known_hosts: True
+
+  pre_tasks:
+
+    - fail:
+        msg: "vm_key_name is required"
+      when: vm_key_name is undefined or not vm_key_name
+
+    - fail:
+        msg: "vm_name is required"
+      when: vm_name is undefined or not vm_name
+
+
+  tasks:
+
+    - name: Docker external access security group
+      os_security_group:
+        description: External access to Docker servers (managed by Ansible)
+        name: docker-devspace-external
+        state: present
+
+    - name: Docker external access security group rules
+      os_security_group_rule:
+        direction: ingress
+        port_range_max: "{{ item }}"
+        port_range_min: "{{ item }}"
+        protocol: tcp
+        remote_ip_prefix: 0.0.0.0/0
+        security_group: docker-devspace-external
+        state: present
+      with_items:
+        - 22
+        - 80
+        - 443
+        - 4063
+        - 4064
+        - 14063
+        - 14064
+        - 8443
+        - 4444
+
+    - name: Docker VM
+      os_server:
+        name: "{{ vm_name }}"
+        state: present
+        image: "{{ vm_image }}"
+        key_name: "{{ vm_key_name }}"
+        flavor: "{{ vm_flavour }}"
+        auto_ip: yes
+        meta:
+          hostname: "{{ vm_name }}"
+          groups: "{{ vm_groups }}"
+        security_groups: [default, docker-devspace-external]
+      register: vmdocker
+
+    # To prevent duplicates with the dynamic inventory only add_host if
+    # the VM was created in this run
+
+    - name: Docker VM hosts files
+      add_host:
+        name: "{{ vm_name }}"
+        groups: "{{ vm_groups }}"
+        ansible_host: "{{ vmdocker.server.public_v4 }}"
+        ansible_user: "centos"
+        ansible_become: true
+
+    - debug:
+        msg: "IPs (Docker) private:{{ vmdocker.openstack.private_v4 }} floating:{{ vmdocker.openstack.public_v4 | default('') }}"

--- a/ansible/roles/devspace/defaults/main.yml
+++ b/ansible/roles/devspace/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+
+# Force Docker to use the MTU set by the main IPV4 interface.
+# This may be necessary on virtualised hosts, see comment in `docker/defaults/main.yml`.
+docker_use_ipv4_nic_mtu: True
+
+# path to snoopy keys
+snoopy_dir_path: "/path/to/snoopy_keys"
+
+# devspace source
+git_repo: "https://github.com/openmicroscopy/devspace.git"
+# devspace branch
+version: "master"
+
+# devspace user
+devuser: centos
+
+# devspace user id
+user_id: "1000"
+
+# path where devspace will be installed
+devhome: /home/{{ devuser }}/devspace
+
+# openstack IP
+openstack_ip: 127.0.0.1
+
+# rename to:
+omero_branch: develop

--- a/ansible/roles/devspace/tasks/main.yml
+++ b/ansible/roles/devspace/tasks/main.yml
@@ -91,6 +91,7 @@
     - { srcfile: ".ssh/snoopycrimecop_github", dest: ".ssh/snoopycrimecop_github" }
     - { srcfile: ".ssh/snoopycrimecop_github.pub", dest: ".ssh/snoopycrimecop_github.pub" }
     - { srcfile: ".gitconfig", dest: ".gitconfig" }
+  when: snoopy_dir_path|length>0
 
 - name: known_hosts
   become: yes

--- a/ansible/roles/devspace/tasks/main.yml
+++ b/ansible/roles/devspace/tasks/main.yml
@@ -1,0 +1,138 @@
+---
+# Setup a devspace
+
+- name: add user {{ devuser }} to docker group
+  become: yes
+  user:
+      name: "{{ devuser }}"
+      comment: "Devspace manintener"
+      uid: "{{ user_id }}"
+      groups: docker
+      append: yes
+
+- name: ensures /home/{{ devuser }}/.ssh dir exists
+  become: yes
+  become_user: "{{ devuser }}"
+  file:
+      path=/home/{{ devuser }}/.ssh
+      state=directory
+      owner={{ devuser }}
+      group={{ devuser }}
+      mode=0700
+
+- name: allow {{ devuser }} to ssh directly
+  become: yes
+  copy: remote_src=yes
+      src={{ ansible_env.HOME }}/.ssh/authorized_keys
+      dest=/home/{{ devuser }}/.ssh/authorized_keys
+      owner={{ devuser }} group={{ devuser }}
+
+- name: install python tools
+  become: yes
+  yum:
+      name: "{{ item }}"
+      state: present
+  with_items:
+    - python-devel
+    - python-pip
+
+- name: install python packages
+  become: yes
+  pip:
+      name: "{{ item }}"
+      #extra_args: "--upgrade"
+      state: latest
+  with_items:
+    - pip
+    - pyyaml
+    - docker-compose
+
+# TEMP: Error: docker-py version is 1.10.2. Minimum version required is 1.7.0.
+# see https://github.com/ansible/ansible/issues/17495
+- name: TODO install docker-py
+  become: yes
+  pip:
+      name: "{{ item }}"
+      state: latest
+  with_items:
+    - docker-py==1.9.0
+
+- name: clone devspace
+  become: yes
+  become_user: "{{ devuser }}"
+  git:
+      repo="{{ git_repo }}"
+      dest={{ devhome }}
+      update=no
+      refspec=+refs/pull/*:refs/heads/*
+      version={{ version }}
+
+- name: ensures .ssh dir exists
+  become: yes
+  become_user: "{{ devuser }}"
+  file:
+      path={{ devhome }}/slave/.ssh
+      state=directory
+      owner={{ devuser }}
+      group={{ devuser }}
+      mode=0700
+
+- name: copy snoopy
+  become: yes
+  become_user: "{{ devuser }}"
+  copy:
+       src={{ snoopy_dir_path }}/{{ item.srcfile }}
+       dest={{ devhome }}/slave/{{ item.dest }}
+       owner={{ devuser }}
+       group={{ devuser }}
+       mode=0700
+  with_items:
+    - { srcfile: ".ssh/config", dest: ".ssh/config" }
+    - { srcfile: ".ssh/snoopycrimecop_github", dest: ".ssh/snoopycrimecop_github" }
+    - { srcfile: ".ssh/snoopycrimecop_github.pub", dest: ".ssh/snoopycrimecop_github.pub" }
+    - { srcfile: ".gitconfig", dest: ".gitconfig" }
+
+- name: known_hosts
+  become: yes
+  become_user: "{{ devuser }}"
+  shell: ssh-keyscan github.com >> {{ devhome }}/slave/.ssh/known_hosts
+- name: chmod known_hosts
+  become: yes
+  become_user: "{{ devuser }}"
+  file:
+      path={{ devhome }}/slave/.ssh/known_hosts
+      mode=0700
+
+- name: change USER_ID
+  become: yes
+  become_user: "{{ devuser }}"
+  replace:
+      dest="{{ devhome }}/{{ item.file }}"
+      regexp='^ARG USER_ID=1000'
+      replace='ARG USER_ID={{ user_id }}' # how to find out UID?
+  with_items:
+    - { file: nginx/Dockerfile }
+    - { file: slave/Dockerfile }
+    - { file: server/Dockerfile }
+    - { file: web/Dockerfile }
+
+- name: ssl cert for jenkins
+  become: yes
+  become_user: "{{ devuser }}"
+  shell: "{{ devhome }}/sslcert /home/{{ devuser }}/devspace/jenkins/sslcert {{ openstack_ip }}"
+  args:
+      chdir: "{{ devhome }}"
+
+- name: ssl cert for nginx
+  become: yes
+  become_user: "{{ devuser }}"
+  shell: "{{ devhome }}/sslcert /home/{{ devuser }}/devspace/nginx/sslcert {{ openstack_ip }}"
+  args:
+      chdir: "{{ devhome }}"
+
+- name: Rrename to {{ omero_branch }}...
+  become: yes
+  become_user: "{{ devuser }}"
+  shell: "{{ devhome }}/rename.py {{ omero_branch }}"
+  args:
+      chdir: "{{ devhome }}"

--- a/ansible/roles/devspace/tasks/main.yml
+++ b/ansible/roles/devspace/tasks/main.yml
@@ -119,14 +119,14 @@
 - name: ssl cert for jenkins
   become: yes
   become_user: "{{ devuser }}"
-  shell: "{{ devhome }}/sslcert /home/{{ devuser }}/devspace/jenkins/sslcert {{ openstack_ip }}"
+  shell: "{{ devhome }}/sslcert {{ devhome }}/jenkins/sslcert {{ openstack_ip }}"
   args:
       chdir: "{{ devhome }}"
 
 - name: ssl cert for nginx
   become: yes
   become_user: "{{ devuser }}"
-  shell: "{{ devhome }}/sslcert /home/{{ devuser }}/devspace/nginx/sslcert {{ openstack_ip }}"
+  shell: "{{ devhome }}/sslcert {{ devhome }}/nginx/sslcert {{ openstack_ip }}"
   args:
       chdir: "{{ devhome }}"
 


### PR DESCRIPTION
This PR shows how to deploy and manage devspace using ansible and docker_service

## Minimum requirements:
 - brief understanding of ansible http://docs.ansible.com/ansible/intro_getting_started.html or tutorial by @joshmoore 
  - inventory http://docs.ansible.com/ansible/intro_inventory.html
  - playbook http://docs.ansible.com/ansible/playbooks.html
 - access to openstack tenancy
 - own ssh key set in openstack tenancy, that name will be used as `vm_key_name`
 - `openrc.sh` http://docs.openstack.org/user-guide/common/cli-set-environment-variables-using-openstack-rc.html
 - snoopy ssh key and gitconfig (* to be discussed

## Deployment
To run devspace run following on the client machine:

- install virtualenv and pip prerequisites:

 ```
$ virtualenv dev
$ source dev/bin/activate
(dev) $ pip install ansible
(dev) $ pip install shade

(dev) $ git clone -b devspace https://github.com/aleksandra-tarkowska/infrastructure.git
(dev) $ cd infrastracture/ansible
```

- create vm (**boot from volume, you no longer have to attach additional volumes**)

 ```
(dev) $ source path/to/openrc.sh
# vm_key_name is a name of ssh key in openstack
# vm_size (default 50GB) is a size of the volume vm boot from. You no longer have to attach additional volumes!
(dev) $ ansible-playbook os-devspace.yml -e vm_name=my-devspace -e vm_key_name=mysshkey
```

  **write down IP of newly created vm, you will need it below to set `openstack_ip`**

- create inventory:

 ```
$ tree /path/to/inventory
devspace
      ├── devspace-hosts
      ├── group_vars
      │   └── devspace
      └── snoopy
          ├── .gitconfig
          └── .ssh

 ```

 - `/path/to/inventory/devspace/devspace-hosts`

    ```
    [devspace]
    10.0.50.100
    ```

 - put snoopy .ssh in `/path/to/inventory/devspace/snoopy/.ssh` that includes:

    ```
    -rwx------.  1    74 Sep 13 15:25 config
    -rwx------.  1  1674 Sep 13 15:25 snoopycrimecop_github
    -rwx------.  1   405 Sep 13 15:25 snoopycrimecop_github.pub
    ```

 - put snoopy gitconfig in `/path/to/inventory/devspace/snoopy/.gitconfig`

 - `/path/to/inventory/devspace/group_vars/devspace`

    ```
    docker_use_ipv4_nic_mtu: True
    devuser: omero
    user_id: "1001"
    devhome: /home/{{ devuser }}/devspace
    openstack_ip: 10.0.50.100
    omero_branch: develop
    snoopy_dir_path: "/path/to/inventory/devspace/snoopy"
    git_repo: "https://github.com/aleksandra-tarkowska/devspace.git"
    version: "round4"
    ```

- install prerequisites as default user with sudo privileges (**assume `centos`**)

 ```
(dev) ansible-playbook -i /path/to/inventory/devspace -u centos devspace.yml
```

- run devspace container (**as user `omero`**)

 ```
(dev) ansible-playbook -i /path/to/inventory/devspace -u omero devspace-runtime.yml
```

this step will take time as for the first time it has to build containers

Jenkins is on https://10.0.50.100:8443 (you have to accept self signed cert)

the same example is in README in https://github.com/openmicroscopy/devspace/pull/50


## NOTE

**there is a bug in latest docker-py**
```
fatal: [10.0.51.143]: FAILED! => {"changed": false, "failed": true, "msg": "Error: docker-py version is 1.10.2. Minimum version required is 1.7.0."}
```
At the moment we are enforcing installation of docker-py=1.9.0, see https://github.com/ansible/ansible/issues/17495

cc : @sbesson @jburel @joshmoore 