### PR TITLE
Downgrade Findbugs version to 3.0.0

### DIFF
--- a/ansible/roles/omero-build/tasks/main.yml
+++ b/ansible/roles/omero-build/tasks/main.yml
@@ -98,16 +98,16 @@
   become: yes
   unarchive:
     copy: no
-    creates: /opt/findbugs-3.0.1/bin/findbugs
+    creates: /opt/findbugs-3.0.0/bin/findbugs
     dest: /opt/
-    src: http://prdownloads.sourceforge.net/findbugs/findbugs-3.0.1.tar.gz?download
+    src: http://prdownloads.sourceforge.net/findbugs/findbugs-3.0.0.tar.gz?download
 
 - name: findbugs | symlink
   become: yes
   file:
     force: yes
     path: /opt/findbugs
-    src: findbugs-3.0.1
+    src: findbugs-3.0.0
     state: link
 
 - name: ninja | create parent dir


### PR DESCRIPTION
While migrating https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-breaking-build/602/ to seabass post provision/deployment, I realized that our code has been tested with FindBugs 3.0.0 and FindBugs 3.0.1 is not supported yet. /cc @kennethgillen 