### PR TITLE
add packages needed for selinux setup

### DIFF
--- a/ansible/roles/omero-server/defaults/main.yml
+++ b/ansible/roles/omero-server/defaults/main.yml
@@ -80,3 +80,10 @@ omero_systemd_setup: False
 # EXPERIMENTAL, may break your system
 # Quoted to prevent autoconversion to bool
 omero_systemd_restart: "no"
+
+# Setup trust store
+omero_trust_store_setup: False
+omero_trust_store: "{{ omero_basedir }}/trust_store.jks"
+omero_trust_store_passwd: omero
+#omero_trust_store_certificates:
+#  - { url: 'https://www.digicert.com/CACerts/DigiCertAssuredIDRootCA.crt', name: 'DigiCertAssuredIDRootCA.crt'}

--- a/ansible/roles/omero-server/handlers/main.yml
+++ b/ansible/roles/omero-server/handlers/main.yml
@@ -6,3 +6,8 @@
   service:
     name: nginx
     state: restarted
+
+- name: update config
+  become: yes
+  become_user: omero
+  shell: "{{ omero_serverdir }}/{{ omero_server_symlink }}/bin/omero load < {{ omero_basedir }}/config/omero-base.config"

--- a/ansible/roles/omero-server/handlers/main.yml
+++ b/ansible/roles/omero-server/handlers/main.yml
@@ -1,13 +1,27 @@
 ---
-# Handler for nginx
 
+# Handler for nginx
 - name: restart nginx
   become: yes
   service:
     name: nginx
     state: restarted
 
+- name: reset config
+  become: yes
+  become_user: omero
+  shell: "{{ omero_serverdir }}/{{ omero_server_symlink }}/bin/omero load < config/reset.config"
+  args:
+    chdir: "{{ omero_basedir }}"
+
 - name: update config
   become: yes
   become_user: omero
   shell: "{{ omero_serverdir }}/{{ omero_server_symlink }}/bin/omero load < {{ omero_basedir }}/config/omero-base.config"
+
+# Handler for OMERO
+- name: restart OMERO
+  become: yes
+  service:
+    name: omero
+    state: restarted

--- a/ansible/roles/omero-server/tasks/main.yml
+++ b/ansible/roles/omero-server/tasks/main.yml
@@ -72,6 +72,7 @@
     dest: "{{ omero_basedir }}/config/omero-base.config"
     force: yes
     src: omero-base.config.j2
+  notify: update config
 
 - name: omero | empty additional configuration file
   become: yes
@@ -88,6 +89,7 @@
     force: yes
     src: "{{ omero_prestart_file }}"
   when: omero_prestart_file | default(None) != None
+  notify: update config
 
 - name: omero | set omego options
   set_fact:

--- a/ansible/roles/omero-server/tasks/main.yml
+++ b/ansible/roles/omero-server/tasks/main.yml
@@ -206,3 +206,6 @@
 
 - include: omero-systemd.yml
   when: omero_systemd_setup
+
+- include: omero-trust-store.yml
+  when: omero_trust_store_setup

--- a/ansible/roles/omero-server/tasks/main.yml
+++ b/ansible/roles/omero-server/tasks/main.yml
@@ -66,13 +66,22 @@
     msg: "OMERO.server found but unable to get version, you may have a corrupt installation"
   when: omero_server_symlink_st.stat.exists and omero_server_version is undefined
 
+- name: omero | create configuration reset file
+  become: yes
+  shell: "touch config/omero-empty.config; cat config/omero-*|grep config|cut -d' ' -f 1,2,3 > config/reset.config"
+  args:
+    chdir: "{{ omero_basedir }}"
+
 - name: omero | create common configuration file
   become: yes
   template:
     dest: "{{ omero_basedir }}/config/omero-base.config"
     force: yes
     src: omero-base.config.j2
-  notify: update config
+  notify:
+    - reset config
+    - update config
+    - restart OMERO
 
 - name: omero | empty additional configuration file
   become: yes
@@ -89,7 +98,10 @@
     force: yes
     src: "{{ omero_prestart_file }}"
   when: omero_prestart_file | default(None) != None
-  notify: update config
+  notify:
+    - reset config
+    - update config
+    - restart OMERO
 
 - name: omero | set omego options
   set_fact:

--- a/ansible/roles/omero-server/tasks/omero-trust-store.yml
+++ b/ansible/roles/omero-server/tasks/omero-trust-store.yml
@@ -1,0 +1,28 @@
+---
+# Configure trust store for OMERO. This might be needed for LDAPS connection.
+
+# The trust store file is built from scratch every time, to make sure it
+# has the exact set of CA certificates configured. For the configuration change
+# to take effect, OMERO must be restarted. To avoid unnecessary restarts, once
+# you have a working setup, set "omero_trust_store_setup: False".
+
+- name: remove existing trust store
+  file: path={{ omero_trust_store }} state=absent
+
+- name: create directory for certificates
+  file: path={{ omero_basedir }}/cacerts state=directory owner={{ omero_system_user }}
+
+- name: download certificates
+  sudo_user: "{{ omero_system_user }}"
+  get_url: url={{ item.url }} dest={{ omero_basedir }}/cacerts/{{ item.name }}
+  with_items:
+    - "{{ omero_trust_store_certificates }}"
+
+- name: import certificates in a trust store file
+  sudo_user: "{{ omero_system_user }}"
+  command: keytool -importcert -noprompt -keystore {{ omero_trust_store }} -storepass {{ omero_trust_store_passwd }} -storetype JKS -providername SUN -file {{ item.name }} -alias {{ item.name }}
+  args:
+    chdir: "{{ omero_basedir }}/cacerts"
+  with_items:
+    - "{{ omero_trust_store_certificates }}"
+  notify: restart OMERO

--- a/ansible/roles/omero-web-runtime/tasks/main.yml
+++ b/ansible/roles/omero-web-runtime/tasks/main.yml
@@ -48,8 +48,12 @@
 - name: omero | install selinux utilities
   become: yes
   yum:
-    name: libselinux-python
+    name: "{{ item }}"
     state: present
+  with_items:
+    - libselinux-python
+    - libsemanage-python
+    - policycoreutils-python
   when: omero_selinux_setup
 
 - name: omero web | selinux booleans


### PR DESCRIPTION
The packages I added are listed in
https://github.com/openmicroscopy/infrastructure/blob/master/ansible/roles/omero-server/tasks/ansible-prerequisites.yml
but that is included only after omero-web-runtime role is included as a dependency in 
https://github.com/openmicroscopy/infrastructure/blob/master/ansible/roles/omero-server/meta/main.yml.

I tested like this:
`ansible-playbook -i omero-deploy/inventory/dev infrastructure/ansible/training-server.yml`
with
`omero_selinux_setup: True`

With `omero_selinux_setup: False` nginx is not allowed to connect to OMERO-web at port 4080. This is on a Vagrant box centos/7.
