### PR TITLE
Fix Vagrantfile so `vagrant up` brings up all nodes

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -51,22 +51,22 @@ Vagrant.configure(2) do |config|
       config.vm.provider :virtualbox do |vb|
         vb.customize ["modifyvm", :id, "--memory", "4096"]
       end
+      node.vm.provision "ansible" do |ansible|
+        ansible.playbook = "idr-playbooks/idr-omero.yml"
+        ansible.limit = "idr"
+        ansible.groups = {
+          "database-hosts" => ["idr-database"],
+          "omero-hosts" => ["idr-omero"],
+          "proxy-hosts" => ["idr-gateway"],
+          "idr:children" => ["database-hosts", "omero-hosts", "proxy-hosts"],
+          "idr:vars" => {
+            # Vagrant uses eth0 for NAT, eth1 for private guest network
+            "idr_net_iface" => "eth1",
+            "idr_nginx_ssl_self_signed" => "True",
+          }
+        }
+      end
     end
-  end
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "idr-playbooks/idr-omero.yml"
-    ansible.groups = {
-      "database-hosts" => ["idr-database"],
-      "omero-hosts" => ["idr-omero"],
-      "proxy-hosts" => ["idr-gateway"],
-      "idr:children" => ["database-hosts", "omero-hosts", "proxy-hosts"],
-      "idr:vars" => {
-        # Vagrant uses eth0 for NAT, eth1 for private guest network
-        "idr_net_iface" => "eth1",
-        "idr_nginx_ssl_self_signed" => "True",
-      }
-    }
-    ansible.limit = "idr"
   end
 
 


### PR DESCRIPTION
The `idr-*` ansible config was previously global, including `ansible.limit = "idr"`. This PR makes it local to just the idr-* nodes now. `vagrant up` should now bring up all nodes.

Current HEAD is broken so tested against c5c56e34563b6dd3e3218b9176ba10ef21b235bd
You might be able to find a more recent working version.