### PR TITLE
Return non-zero error code if no hosts match

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -26,6 +26,9 @@ inventory_ignore_extensions = ~, .orig, .bak, .ini, .retry, .pyc, .pyo, .html, .
 # Helps determine what's running slowly
 callback_whitelist = profile_tasks
 
+# Additional plugins
+callback_plugins = ./plugins/callback
+
 # Performance options
 [ssh_connection]
 pipelining = True

--- a/ansible/plugins/callback/error_if_no_hosts_match.py
+++ b/ansible/plugins/callback/error_if_no_hosts_match.py
@@ -1,0 +1,39 @@
+# https://gist.github.com/jjshoe/ace3070906e5bc5cc432
+# https://github.com/ansible/ansible/pull/14742
+# https://github.com/ansible/ansible/issues/14693
+
+# Make coding more python3-ish
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import time
+import sys
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    """
+    This callback module exits with non-zero if no hosts match
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'no_hosts_match_exit_non_zero'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+    def playbook_on_stats(self, stats):
+        found_stats = False
+
+        for key in ['ok', 'failures', 'dark', 'changed', 'skipped']:
+            if len(getattr(stats, key)) > 0:
+                found_stats = True
+                break
+
+        if found_stats == False:
+            print('ERROR: No hosts matched')
+            sys.exit(10)


### PR DESCRIPTION
This adds a callback so that Ansible will set a non-zero exit code if a playbook was run but no hosts match.  This is useful when running ansible-playbook automatically. For example, when running vagrant to test the Vagrantfile if there is a mismatch between the hosts expect by the playbook and the hosts in the Vagrantfile ansible would normally not care.

If you think this is inappropriate it could go into an alternative `ansible.cfg` which is used only by `vagrant` (e.g. set `ANSIBLE_CONFIG`)