### PR TITLE
Revert some performance improvement changes to ansible.cfg

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -24,7 +24,7 @@ retry_files_enabled = False
 inventory_ignore_extensions = ~, .orig, .bak, .ini, .retry, .pyc, .pyo, .html, .omero, .gif, .png, .js, .md
 
 # Helps determine what's running slowly
-callback_whitelist = profile_tasks
+#callback_whitelist = profile_tasks
 
 # Performance options
 [ssh_connection]

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -28,4 +28,4 @@ callback_whitelist = profile_tasks
 
 # Performance options
 [ssh_connection]
-pipelining = True
+#pipelining = True


### PR DESCRIPTION
They're both useful but profiling adds extra output which obscures the rest of the ansible-playbook output, and `pipelining` is causing problems at the moment. These should be investigated later.