### PR TITLE
Change omero_prestart_file to a j2 template

### DIFF
--- a/ansible/roles/omero-server/defaults/main.yml
+++ b/ansible/roles/omero-server/defaults/main.yml
@@ -61,8 +61,8 @@ omero_omego_additional_args: ""
 # Dictionary of additional OMERO configuration options
 omero_server_config: {}
 
-# Optional path to an additional file to be passed to `omero load ...`
-# before starting the server
+# Optional path to an additional template-file to be passed to
+# `omero load ...` before starting the server
 omero_prestart_file:
 
 # Setup OMERO.web

--- a/ansible/roles/omero-server/tasks/main.yml
+++ b/ansible/roles/omero-server/tasks/main.yml
@@ -83,7 +83,7 @@
 
 - name: omero | copy additional configuration file
   become: yes
-  copy:
+  template:
     dest: "{{ omero_basedir }}/config/omero-additional.config"
     force: yes
     src: "{{ omero_prestart_file }}"


### PR DESCRIPTION
Treat the config.omero file specified by `omero_prestart_file` as a Jinja2 template. In practice this means anything in `{{ ... }}` will be transformed, otherwise it should be the same as the previous behaviour.

Motivation: Allow most configuration to be public whilst having a placeholder for sensitive configuration information. For example if the file contains: `config set omero.web.public.password {{ secret_password | default("omero") }}` this will be interpreted as
- `config set omero.web.public.password omero` by default
- `config set omero.web.public.password <secret_password>` if the variable `secret_password` is defined