### PR TITLE
Add docker-tools role to install docker-compose globally

### DIFF
--- a/ansible/roles/docker-tools/README.md
+++ b/ansible/roles/docker-tools/README.md
@@ -1,0 +1,14 @@
+Docker Tools
+============
+
+Install Python based docker tools, such as `docker-compose`.
+
+This uses a mix of python modules from yum and modules installed globally with `pip`.
+
+If your system hosts multiple services you should use a virtualenv (not currently implemented by this role) instead of installing docker-compose globally.
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/docker-tools/tasks/main.yml
+++ b/ansible/roles/docker-tools/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 # Install additional docker tools globally
 
+- name: system packages | install epel repo
+  become: yes
+  yum:
+    name: epel-release
+    state: present
+
 # Install as many python dependencies using RPMs if possible to reduce risk
 # of future conflicts
 - name: docker | Install docker python tools

--- a/ansible/roles/docker-tools/tasks/main.yml
+++ b/ansible/roles/docker-tools/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# Install additional docker tools globally
+
+# Install as many python dependencies using RPMs if possible to reduce risk
+# of future conflicts
+- name: docker | Install docker python tools
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - python-devel
+  - python-pip
+  - PyYAML
+  - python-six
+  - python-requests
+
+# TODO: Ansible fails with latest version of docker-py
+# Error: docker-py version is 1.10.2. Minimum version required is 1.7.0.
+# See https://github.com/ansible/ansible/issues/17495
+#
+# The latest docker-compose requires docker-py==1.10.3, so cap version
+# https://github.com/docker/compose/blob/1.8.1/requirements.txt#L4
+- name: docker swarm | install python packages
+  become: yes
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - docker-py==1.9.0
+  - docker-compose==1.8.0

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -9,6 +9,7 @@
 - hosts: docker
   roles:
   - role: docker
+  - role: docker-tools
 
 - hosts: redis
   roles:


### PR DESCRIPTION
I need this for the IDR so created this role based on https://github.com/openmicroscopy/infrastructure/blob/master/ansible/roles/devspace/tasks/main.yml

If everyone's happy I'll update `roles/devspace` to depend on this.

/cc @aleksandra-tarkowska 