### PR TITLE
Devspace playbook: mount squig using Samba

### DIFF
--- a/ansible/devspace.yml
+++ b/ansible/devspace.yml
@@ -8,3 +8,15 @@
     - role: docker
     - role: versioncontrol-utils
     - role: devspace
+    - role: samba-client
+
+  tasks:
+
+    - name: Mount samba share
+      become: yes
+      mount:
+        fstype: cifs
+        name: /data_repo
+        opts: "credentials=/etc/fstab.datarepo.creds,ro"
+        src: \\squig.openmicroscopy.org.uk\ome-data-repo
+        state: mounted

--- a/ansible/devspace.yml
+++ b/ansible/devspace.yml
@@ -16,7 +16,7 @@
       become: yes
       mount:
         fstype: cifs
-        name: /data_repo
+        name: /ome/data_repo
         opts: "credentials=/etc/fstab.datarepo.creds,ro"
-        src: \\squig.openmicroscopy.org.uk\ome-data-repo
+        src: //squig.openmicroscopy.org.uk/ome-data-repo
         state: mounted

--- a/ansible/os-devspace.yml
+++ b/ansible/os-devspace.yml
@@ -21,9 +21,6 @@
     vm_groups: "ansible-managed,os-image-centos,docker-hosts,devspace"
     ignore_internal_known_hosts: True
 
-  roles:
-    - role: samba-client
-
   pre_tasks:
 
     - fail:
@@ -93,14 +90,3 @@
 
     - debug:
         msg: "IPs (Docker) private:{{ vmdocker.openstack.private_v4 }} floating:{{ vmdocker.openstack.public_v4 | default('') }}"
-
-  
-    - name: Mount samba share
-      become: yes
-      mount:
-        fstype: cifs
-        name: /data_repo/
-        opts: "credentials={{ samba_credentials_file }},ro"
-        src: //squig.openmicroscopy.org.uk/ome-data-repo/
-        state: mounted
-      when: use_samba

--- a/ansible/os-devspace.yml
+++ b/ansible/os-devspace.yml
@@ -21,6 +21,9 @@
     vm_groups: "ansible-managed,os-image-centos,docker-hosts,devspace"
     ignore_internal_known_hosts: True
 
+  roles:
+    - role: samba-client
+
   pre_tasks:
 
     - fail:
@@ -90,3 +93,14 @@
 
     - debug:
         msg: "IPs (Docker) private:{{ vmdocker.openstack.private_v4 }} floating:{{ vmdocker.openstack.public_v4 | default('') }}"
+
+  
+    - name: Mount samba share
+      become: yes
+      mount:
+        fstype: cifs
+        name: /data_repo/
+        opts: "credentials={{ samba_credentials_file }},ro"
+        src: //squig.openmicroscopy.org.uk/ome-data-repo/
+        state: mounted
+      when: use_samba


### PR DESCRIPTION
See https://trello.com/c/Rfc6NXgr/2257-mount-squig-in-ci-provision-yml-playbooks

In preparation of the upcoming Bio-Formats 5.3.0 work, this PR adds support for mounting squig as a read-only Samba share in the OpenStack devspaces. With a corresponding PR, this should allow to port the repository Bio-Formats jobs to the development space.