### PR TITLE
Exe4j: license

### DIFF
--- a/ansible/roles/omero-build/defaults/main.yml
+++ b/ansible/roles/omero-build/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for roles/omero-build
+
+# A license key (default null)
+exe4j_license_key:

--- a/ansible/roles/omero-build/tasks/main.yml
+++ b/ansible/roles/omero-build/tasks/main.yml
@@ -97,7 +97,7 @@
 - name: exe4j packages | install license
   become: yes
   command: exe4jc -L="{{ exe4j_license_key }}"
-  when: exe4j_license_key is defined
+  when: exe4j_license_key
 
 - name: findbugs | download and extract
   become: yes

--- a/ansible/roles/omero-build/tasks/main.yml
+++ b/ansible/roles/omero-build/tasks/main.yml
@@ -94,6 +94,11 @@
     name: http://download-aws.ej-technologies.com/exe4j/exe4j_linux_5_0_1.rpm
     state: present
 
+- name: exe4j packages | install license
+  become: yes
+  command: exe4jc -L="{{ exe4j_license_key }}"
+  when: exe4j_license_key is defined
+
 - name: findbugs | download and extract
   become: yes
   unarchive:
@@ -107,6 +112,7 @@
   file:
     force: yes
     path: /opt/findbugs
+    
     src: findbugs-3.0.0
     state: link
 


### PR DESCRIPTION
Noticed by @jburel during OMERO 5.2.6 release process. This should add a conditional step in the `omero-build` role to install `exe4j` license from a string.