### PR TITLE
omero-build: add defaults to fix spacewalk issue

### DIFF
--- a/ansible/roles/omero-build/defaults/main.yml
+++ b/ansible/roles/omero-build/defaults/main.yml
@@ -3,3 +3,5 @@
 
 # A license key (default null)
 exe4j_license_key:
+
+spacewalk: False


### PR DESCRIPTION
This works around an issue that has appeared a few times recently. I also failed to properly set this from the command-line with `-e spacewalk=True` (i.e. my tasks were still not activating)

Likely a rethink is needed of the spacewalk boolean. Perhaps it can be wrapped as an entire role.