### PR TITLE
Postgres revert role privileges

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -19,6 +19,14 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "postgres" do |postgres|
+    postgres.vm.box = "centos/7"
+    postgres.vm.provision "ansible" do |ansible|
+      ansible.verbose = "v"
+      ansible.playbook = "test.yml"
+    end
+  end
+
   config.vm.define "redis" do |redis|
     redis.vm.box = "centos/7"
     redis.vm.provision "ansible" do |ansible|

--- a/ansible/roles/postgresql/README.md
+++ b/ansible/roles/postgresql/README.md
@@ -12,7 +12,11 @@ Defaults: `defaults/main.yml`
 
 - `postgresql_version`: The PostgreSQL version, either 9.4 (default) or 9.3
 - `postgresql_install_server`: If True (default) install and initialise the server, otherwise only install the client
-- `postgresql_users_databases`: List of dictionaries of users and databases in the form `[{user: db-user, password: db-password, databases: [List of database names]}]`, only works if `postgresql_install_server` is `True`
+- `postgresql_users_databases`: List of dictionaries of users and databases, ignored unless `postgresql_install_server` is `True`. Items should be of the form:
+  - `user`: Database username
+  - `password`: Database user password
+  - `databases`: [List of database names that user has access to]
+  - `roles`: Role attribute flags, optional
 - `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `'*'` for all
 - `postgresql_server_auth_local`: Whether to allow the default postgres local authentication (default `True`)
 - `postgresql_server_auth`: List of dictionaries of authorisation parameters, if omitted the default local authentication only will be enabled. Items should be of the form:

--- a/ansible/roles/postgresql/tasks/databases.yml
+++ b/ansible/roles/postgresql/tasks/databases.yml
@@ -29,7 +29,7 @@
     encrypted: yes
     name: "{{ item.0.user }}"
     password: "{{ item.0.password }}"
-    role_attr_flags: "CREATEDB,NOSUPERUSER"
+    role_attr_flags: "{{ item.0.roles | default(omit) }}"
     state: present
   with_subelements:
     - "{{ postgresql_users_databases }}"

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -36,3 +36,40 @@
   roles:
   - role: cli-utils
     # Should automatically bring in basedeps
+
+- hosts: postgres
+  roles:
+  - postgresql
+  vars:
+  - postgresql_server_listen: "'*'"
+  - postgresql_server_auth:
+    - database: publicdb
+      user: alice123
+      address: 192.168.1.0/24
+  - postgresql_users_databases:
+    - user: alice
+      password: alice123
+      databases: [publicdb, secretdb]
+    - user: bob
+      password: bob123
+      databases: [publicdb]
+      roles: "CREATEDB,NOSUPERUSER"
+
+  # Testing
+
+  tasks:
+  - command: psql postgres -c "SELECT * FROM pg_roles WHERE rolname='alice'" -At
+    become: yes
+    become_user: postgres
+    register: pg_alice
+
+  - command: psql postgres -c "SELECT * FROM pg_roles WHERE rolname='bob'" -At
+    become: yes
+    become_user: postgres
+    register: pg_bob
+
+  - assert:
+      that:
+      # Everything except the UID
+      - "pg_alice.stdout.startswith('alice|f|t|f|f|f|t|f|-1|********|||')"
+      - "pg_bob.stdout.startswith('bob|f|t|f|t|f|t|f|-1|********|||')"


### PR DESCRIPTION
Reverts the change to the `postgres` role from https://github.com/openmicroscopy/infrastructure/commit/cd92c3d2bfe7f52bb65d0f822db30c9669d8fd74#diff-5c81521b75eb3f697f59fd8f1d245303 and replaces it with a new optional parameter. Also adds a vagrant test including some asserts.