### PR TITLE
Bump devspace role version to 0.3.1

### DIFF
--- a/ansible/devspace.yml
+++ b/ansible/devspace.yml
@@ -3,6 +3,10 @@
 
 - hosts: devspace
 
+  vars:
+    # Overrides the default value in the docker role
+    docker_use_ipv4_nic_mtu: True
+
   vars_prompt:
     - name: "jenkins_nginx_password"
       prompt: "Enter Jenkins password"

--- a/ansible/roles/devspace/defaults/main.yml
+++ b/ansible/roles/devspace/defaults/main.yml
@@ -10,7 +10,7 @@ snoopy_dir_path: ""
 # devspace source
 git_repo: "https://github.com/openmicroscopy/devspace.git"
 # devspace branch
-version: "0.3.0"
+version: "0.3.1"
 
 # devspace user
 devuser: omero

--- a/ansible/roles/devspace/tasks/devspace-install.yml
+++ b/ansible/roles/devspace/tasks/devspace-install.yml
@@ -117,6 +117,7 @@
     regexp: '^ARG USER_ID=1000'
     replace: 'ARG USER_ID={{ user_id }}' # how to find out UID?
   with_items:
+    - bf/Dockerfile
     - nginx/Dockerfile
     - slave/Dockerfile
     - server/Dockerfile


### PR DESCRIPTION
This should use the last tag (and make the corresponding changes).

This PR is currently redeployed on the BF 5.3 devspace with a minimal host_var file

````
docker_use_ipv4_nic_mtu: True
omero_branch: dev_5_3
````