### PR TITLE
Work around websocket proxy issue: set Host header

### DIFF
--- a/ansible/roles/nginx-proxy/README.md
+++ b/ansible/roles/nginx-proxy/README.md
@@ -46,6 +46,7 @@ Backend servers:
   - `cache_validity`: The time that an object should be cached for, if omitted caching is disabled for this backend
   - `websockets`: If `True` enable proxying of websockets, default `False`
   - `read_timeout`: The proxy read timeout, optional
+  - `host_header`: Optionally set the Host header, you shouldn't need to set this unless you're trying to work around bugs in applications
 
 - `nginx_proxy_streams`: List of dictionaries of backend streaming servers
   - `name`: A variable name used for grouping multiple upstream servers

--- a/ansible/roles/nginx-proxy/templates/nginx-confd-proxy.j2
+++ b/ansible/roles/nginx-proxy/templates/nginx-confd-proxy.j2
@@ -146,6 +146,10 @@ server {
 {%   if 'read_timeout' in item %}
         proxy_read_timeout {{ item.read_timeout }};
 {%   endif %}
+
+{%   if 'host_header' in item %}
+        proxy_set_header Host {{ item.host_header }};
+{%   endif %}
     }
 
 {% endfor %}


### PR DESCRIPTION
Follow up to https://github.com/openmicroscopy/infrastructure/pull/140. Adds a workaround for webproxy connections where the `Host` header seems to be incorrect, even though it's already set in the `server` scope.