### PR TITLE
New role to hide SELinux issues

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -51,6 +51,13 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "selinux" do |selinux|
+    selinux.vm.box = "centos/7"
+    selinux.vm.provision "ansible" do |ansible|
+      ansible.playbook = "test.yml"
+    end
+  end
+
   config.vm.define "training-server" do |training|
     training.vm.box = "centos/7"
     training.vm.provision "ansible" do |ansible|

--- a/ansible/roles/nginx-proxy/meta/main.yml
+++ b/ansible/roles/nginx-proxy/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
+- role: selinux-utils
 - role: nginx

--- a/ansible/roles/nginx-proxy/tasks/main.yml
+++ b/ansible/roles/nginx-proxy/tasks/main.yml
@@ -9,11 +9,8 @@
   notify:
     - restart nginx
 
-# TODO: ansible_selinux.status == "enabled" should autodetect SELinux,
-# but may give a misleading result if a dependency is missing:
-# https://github.com/ansible/ansible/issues/16612
 - include: nginx-selinux.yml
-  when: ansible_selinux and ansible_selinux.status == "enabled"
+  when: selinux_enabled
 
 - include: nginx-cache.yml
 

--- a/ansible/roles/selinux-utils/README.md
+++ b/ansible/roles/selinux-utils/README.md
@@ -1,0 +1,29 @@
+SELinux Utils
+=============
+
+Sets a host variable indicating whether SELinux is enabled or not.
+Installs utilities for interacting with SELinux if it is.
+
+These utilities may be required by some Ansible modules when SELinux is enabled, and are not always present in CentOS 7 base images.
+
+This role will set the host variable `selinux_enabled: {True,False}` which can be used in later roles.
+
+Ideally this role should be included as a dependency in `meta/main.yml` of any roles that need to know whether SELinux is enabled.
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+      - selinux-utils
+      tasks:
+        debug:
+          msg: "SELinux is enabled or permissive"
+        when: selinux_enabled
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/selinux-utils/tasks/main.yml
+++ b/ansible/roles/selinux-utils/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# tasks file for roles/selinux-utils
+
+# NOTE: The Ansible variable `ansible_selinux.status == "enabled"` should
+# autodetect SELinux, but may give a misleading result if a dependency is
+# missing: https://github.com/ansible/ansible/issues/16612
+# so use getsestatus instead
+
+# Always run including in check mode
+- name: selinux | check enabled
+  become: yes
+  command: getenforce
+  register: selinux_getenforce
+  always_run: True
+  failed_when: "selinux_getenforce.rc != 0 and selinux_getenforce.rc != 127"
+  changed_when: False
+  # 127=command not found, implies selinux disabled
+
+- name: system packages | set selinux variable
+  set_fact:
+    selinux_enabled: "{{ selinux_getenforce.rc == 0 and selinux_getenforce.stdout != 'Disabled' }}"
+
+- name: system packages | install selinux utilities
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libselinux-python
+    - libsemanage-python
+    - policycoreutils-python
+  when: selinux_enabled

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -73,3 +73,13 @@
       # Everything except the UID
       - "pg_alice.stdout.startswith('alice|f|t|f|f|f|t|f|-1|********|||')"
       - "pg_bob.stdout.startswith('bob|f|t|f|t|f|t|f|-1|********|||')"
+
+
+- hosts: selinux
+  roles:
+  - selinux-utils
+  tasks:
+  - assert:
+      # This assumes we're testing on the centos-7 Vagrantbox which has
+      # selinux enabled. Use `is sameas` to also assert type
+      that: "{{ selinux_enabled is sameas True }}"


### PR DESCRIPTION
There are several roles which require conditional tasks depending on whether SELinux is enabled or not. Furthermore Ansible has some SELinux package dependencies which aren't always installed by default. This role abstracts away all that complexity:
- Sets a host-variable `selinux_enabled`: `True`/`False`, this can be checked in other roles or playbooks
- If SELinux is enabled or permissive installs SELinux dependencies required by Ansible, otherwise it doesn't
- See the README for details.

This also modifies the `nginx-proxy` role to use this new role. Other roles can be updated in separate PRs.
