### PR TITLE
Use docker swarm with IDR JupyterHub

### DIFF
--- a/ansible/idr-playbooks/files/jupyterhub-docker-swarm.j2
+++ b/ansible/idr-playbooks/files/jupyterhub-docker-swarm.j2
@@ -1,0 +1,33 @@
+[Unit]
+Description=IDR JupyterHub
+Requires=docker.service
+After=docker.service
+
+[Service]
+# docker service will tell the docker daemon to manage the lifetime of
+# containers, including restarting on failure. It will also automatically
+# restart the service following a reboot, so take care to ensure it doesn't
+# conflict with systemd
+Restart=no
+Type=oneshot
+RemainAfterExit=True
+ExecStartPre=-/usr/bin/docker service rm {{ idr_jupyter_service }}
+ExecStart=/usr/bin/docker service create \
+    --name  {{ idr_jupyter_service }} \
+    --network {{ idr_jupyter_network }} \
+    --log-driver {{ idr_jupyter_log_driver }} \
+    -p 8000:8000 \
+    -p 8081:8081 \
+    -e DOCKER_HOST=unix://var/run/docker.sock \
+    --mount source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind \
+    --mount source=/srv/jupyterhub/jupyterhub_config.py,target=/srv/jupyterhub/jupyterhub_config.py,type=bind,readonly=true \
+    {{ idr_jupyter_hub_image }} \
+    jupyterhub \
+    --no-ssl \
+    --base-url={{ idr_jupyter_prefix }} \
+    -f /srv/jupyterhub/jupyterhub_config.py \
+    --log-level={{ idr_jupyter_hub_log_level }}
+ExecStop=/usr/bin/docker service rm {{ idr_jupyter_service }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/idr-playbooks/files/jupyterhub-docker.j2
+++ b/ansible/idr-playbooks/files/jupyterhub-docker.j2
@@ -7,10 +7,10 @@ After=docker.service
 #Restart=on-failure
 Restart=no
 RestartSec=10
-ExecStartPre=-/usr/bin/docker kill omero-jupyter
-ExecStartPre=-/usr/bin/docker rm omero-jupyter
+ExecStartPre=-/usr/bin/docker kill {{ idr_jupyter_service }}
+ExecStartPre=-/usr/bin/docker rm {{ idr_jupyter_service }}
 ExecStart=/usr/bin/docker run \
-    --name omero-jupyter \
+    --name {{ idr_jupyter_service }} \
     -p 8000:8000 \
     -p 8081:8081 \
     -e DOCKER_HOST=unix://var/run/docker.sock \
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/docker run \
     --base-url={{ idr_jupyter_prefix }} \
     -f /srv/jupyterhub/jupyterhub_config.py \
     --log-level={{ idr_jupyter_hub_log_level }}
-ExecStop=/usr/bin/docker stop omero-jupyter
+ExecStop=/usr/bin/docker stop {{ idr_jupyter_service }}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/idr-playbooks/files/jupyterhub_config-py.j2
+++ b/ansible/idr-playbooks/files/jupyterhub_config-py.j2
@@ -52,9 +52,9 @@ c.DockerServiceSpawner.remove_containers = {{ idr_jupyter_notebook_remove_contai
 c.DockerServiceSpawner.use_internal_ip = True
 c.DockerServiceSpawner.network_name = "{{ idr_jupyter_network }}"
 {% if idr_jupyter_notebook_volumes | default(None) %}
-c.DockerSpawner.volumes = {{ idr_jupyter_notebook_volumes }}
+c.DockerServiceSpawner.volumes = {{ idr_jupyter_notebook_volumes }}
 {% endif %}
-
+c.DockerServiceSpawner.log_driver = "{{ idr_jupyter_log_driver }}"
 
 ######################################################################
 # Authenticator

--- a/ansible/idr-playbooks/files/jupyterhub_config-py.j2
+++ b/ansible/idr-playbooks/files/jupyterhub_config-py.j2
@@ -44,6 +44,9 @@ c.DockerSpawner.volumes = {{ idr_jupyter_notebook_volumes }}
 # DockerServiceSpawner
 # https://github.com/manics/dockerspawner/blob/master/dockerspawner/dockerservicespawner.py
 
+# Docker swarm may take a while to start a container
+c.DockerServiceSpawner.start_timeout = 180
+c.DockerServiceSpawner.debug = True
 c.DockerServiceSpawner.tls_verify = False
 #c.DockerServiceSpawner.hub_ip_connect = "{{ idr_jupyter_ip }}"
 c.DockerServiceSpawner.hub_ip_connect = "{{ idr_jupyter_service }}"

--- a/ansible/idr-playbooks/files/jupyterhub_config-py.j2
+++ b/ansible/idr-playbooks/files/jupyterhub_config-py.j2
@@ -10,8 +10,14 @@ c = get_config()
 c.JupyterHub.hub_ip = "0.0.0.0"
 #c.JupyterHub.proxy_api_ip = c.JupyterHub.hub_ip
 
+{%if docker_swarm_enabled %}
+c.JupyterHub.spawner_class = "dockerspawner.DockerServiceSpawner"
+{% else %}
 c.JupyterHub.spawner_class = "dockerspawner.DockerSpawner"
-c.JupyterHub.authenticator_class = "oauthenticator.GitHubOAuthenticator"
+{% endif %}
+{%if idr_jupyter_authenticator | default(None) %}
+c.JupyterHub.authenticator_class = "{{ idr_jupyter_authenticator }}"
+{% endif %}
 {% if idr_jupyter_proxy_token | default(None) %}
 c.JupyterHub.proxy_auth_token = "{{ idr_jupyter_proxy_token }}"
 {% endif %}
@@ -19,8 +25,8 @@ c.JupyterHub.proxy_auth_token = "{{ idr_jupyter_proxy_token }}"
 
 ######################################################################
 # DockerSpawner
-
 # https://github.com/jupyterhub/dockerspawner/blob/master/dockerspawner/dockerspawner.py
+
 c.DockerSpawner.tls_verify = False
 #c.DockerSpawner.tls_ca = "/etc/docker/ca.pem"
 #c.DockerSpawner.tls_cert = "/etc/docker/server-cert.pem"
@@ -28,9 +34,23 @@ c.DockerSpawner.tls_verify = False
 #c.DockerSpawner.container_ip = "0.0.0.0"
 c.DockerSpawner.hub_ip_connect = "{{ idr_jupyter_ip }}"
 c.DockerSpawner.container_image = "{{ idr_jupyter_notebook_image }}"
-
 c.DockerSpawner.remove_containers = {{ idr_jupyter_notebook_remove_containers | default(False) }}
 c.DockerSpawner.use_internal_ip = True
+{% if idr_jupyter_notebook_volumes | default(None) %}
+c.DockerSpawner.volumes = {{ idr_jupyter_notebook_volumes }}
+{% endif %}
+
+######################################################################
+# DockerServiceSpawner
+# https://github.com/manics/dockerspawner/blob/master/dockerspawner/dockerservicespawner.py
+
+c.DockerServiceSpawner.tls_verify = False
+#c.DockerServiceSpawner.hub_ip_connect = "{{ idr_jupyter_ip }}"
+c.DockerServiceSpawner.hub_ip_connect = "{{ idr_jupyter_service }}"
+c.DockerServiceSpawner.container_image = "{{ idr_jupyter_notebook_image }}"
+c.DockerServiceSpawner.remove_containers = {{ idr_jupyter_notebook_remove_containers | default(False) }}
+c.DockerServiceSpawner.use_internal_ip = True
+c.DockerServiceSpawner.network_name = "{{ idr_jupyter_network }}"
 {% if idr_jupyter_notebook_volumes | default(None) %}
 c.DockerSpawner.volumes = {{ idr_jupyter_notebook_volumes }}
 {% endif %}

--- a/ansible/idr-playbooks/idr-docker.yml
+++ b/ansible/idr-playbooks/idr-docker.yml
@@ -20,7 +20,8 @@
   # This sets a host_var on all docker-hosts which can be used in other plays
   - name: enable/disable docker swarm
     set_fact:
-      docker_swarm_enabled: False
+      #docker_swarm_enabled: False
+      docker_swarm_enabled: True
 
   roles:
 
@@ -199,7 +200,26 @@
     command: docker pull "{{ idr_jupyter_notebook_image }}"
     when: docker_image_jhnote.changed
 
-  # Only enable systemd service when not using docker swarm
+
+  # Docker swarm: setup network
+  # TODO: Use docker_network in Ansible 2.2
+
+  - name: jupyterhub | check docker swarm network
+    become: yes
+    command: docker network inspect "{{ idr_jupyter_network }}"
+    always_run: yes
+    register: docker_jupyter_net
+    when: docker_swarm_enabled
+    changed_when: "docker_jupyter_net.rc != 0"
+    failed_when: "docker_jupyter_net.rc > 1"
+
+  - name: jupyterhub | create docker swarm network
+    become: yes
+    command: docker network create --driver overlay "{{ idr_jupyter_network }}"
+    when: docker_swarm_enabled and docker_jupyter_net.changed
+
+
+  # Without Docker swarm: start and enable the service
 
   - name: jupyterhub | create systemd service
     become: yes
@@ -207,28 +227,33 @@
       src: files/jupyterhub-docker.j2
       dest: /etc/systemd/system/docker-jupyterhub.service
     register: systemdjupyter
+    when: not docker_swarm_enabled
 
   - name: jupyterhub | reload systemd
     become: yes
     command: systemctl daemon-reload
-    when: systemdjupyter.changed
+    when: systemdjupyter.changed and not docker_swarm_enabled
 
   - name: jupyterhub | restart
     become: yes
     service:
       name: docker-jupyterhub.service
-      state: "{{ docker_swarm_enabled | ternary('stopped', 'restarted') }}"
-    when: jupyterconfig.changed
+      state: restarted
+    when: jupyterconfig.changed and not docker_swarm_enabled
 
   - name: jupyterhub | enable jupyterhub
     become: yes
     service:
-      enabled: "{{ docker_swarm_enabled | ternary('no', 'yes') }}"
+      enabled: "yes"
       name: docker-jupyterhub.service
-      state: "{{ docker_swarm_enabled | ternary('stopped', 'started') }}"
+      state: started
+    when: not docker_swarm_enabled
 
 
-  # Docker swarm: setup network and start the service
+  # Docker swarm:
+  # - setup network
+  # - start/restart the service if necessary
+  # - don't enable it since swarm will auto-start the service
   # TODO: Use docker_network when we switch to Ansible 2.2
 
   - name: jupyterhub | check docker swarm network
@@ -242,16 +267,26 @@
 
   - name: jupyterhub | create docker swarm network
     become: yes
-    command: docker network create --driver overlay --subnet "{{ idr_jupyter_subnet }}" "{{ idr_jupyter_network }}"
+    command: docker network create --driver overlay "{{ idr_jupyter_network }}"
     when: docker_swarm_enabled and docker_jupyter_net.changed
 
-  - name: jupyterhub | stop docker jupyter service
+  - name: jupyterhub | create swarm systemd service
     become: yes
-    command: docker service rm "{{ idr_jupyter_service }}"
-    when: docker_swarm_enabled and jupyterconfig.changed
-    failed_when: False
+    template:
+      src: files/jupyterhub-docker-swarm.j2
+      dest: /etc/systemd/system/docker-jupyterhub.service
+    register: systemdjupyter
+    when: docker_swarm_enabled
 
-  - name: jupyterhub | check docker jupyter service
+  - name: jupyterhub | reload systemd
+    become: yes
+    command: systemctl daemon-reload
+    when: systemdjupyter.changed and docker_swarm_enabled
+
+  # Docker swarm may have started the service without telling systemd
+  # so only restart if the config has changed or the service isn't
+  # running
+  - name: jupyterhub | check docker swarm service
     become: yes
     command: docker service inspect "{{ idr_jupyter_service }}"
     always_run: yes
@@ -260,46 +295,16 @@
     changed_when: "docker_jupyter_service.rc != 0"
     failed_when: "docker_jupyter_service.rc > 1"
 
-  - name: jupyterhub | create docker jupyter service
+  - name: jupyterhub | restart swarm
     become: yes
-    command: >
-      docker service create
-          --name {{ idr_jupyter_service }}
-          --network {{ idr_jupyter_network }}
-          --log-driver journald
-          -p 8000:8000
-          -p 8081:8081
-          -e DOCKER_HOST=unix://var/run/docker.sock
-          --mount source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind
-          --mount source=/srv/jupyterhub/jupyterhub_config.py,target=/srv/jupyterhub/jupyterhub_config.py,type=bind,readonly=true
-          {{ idr_jupyter_hub_image }}
-          jupyterhub
-          --no-ssl
-          --base-url={{ idr_jupyter_prefix }}
-          -f /srv/jupyterhub/jupyterhub_config.py
-          --log-level={{ idr_jupyter_hub_log_level }}
-    when: docker_swarm_enabled and docker_jupyter_service.changed
+    service:
+      enabled: "no"
+      name: docker-jupyterhub.service
+      state: restarted
+    when: docker_swarm_enabled and (jupyterconfig.changed or docker_jupyter_service.changed)
 
-  - name: jupyterhub | docker jupyter service script
-    become: yes
-    copy:
-      dest: /docker-jupyter.sh
-      content: >
-            docker service create
-            --name {{ idr_jupyter_service }}
-            --network {{ idr_jupyter_network }}
-            --log-driver journald
-            -p 8000:8000
-            -p 8081:8081
-            -e DOCKER_HOST=unix://var/run/docker.sock
-            --mount source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind
-            --mount source=/srv/jupyterhub/jupyterhub_config.py,target=/srv/jupyterhub/jupyterhub_config.py,type=bind,readonly=true
-            {{ idr_jupyter_hub_image }}
-            jupyterhub
-            --no-ssl
-            --base-url={{ idr_jupyter_prefix }}
-            -f /srv/jupyterhub/jupyterhub_config.py
-            --log-level={{ idr_jupyter_hub_log_level }}
+
+  # Notebooks
 
   - name: jupyterhub | check if idr-notebooks repo exists
     stat:
@@ -339,12 +344,16 @@
   vars:
   - idr_jupyter_service: omero-jupyter
   - idr_jupyter_network: omero-jupyter-net
-  - idr_jupyter_subnet: "172.21.0.0/16"
+  # https://docs.docker.com/engine/admin/logging/overview/
+  - idr_jupyter_log_driver: journald
   - idr_jupyter_authenticator: "oauthenticator.GitHubOAuthenticator"
+  #- idr_jupyter_authenticator: "dummyauthenticator.DummyAuthenticator"
   #- idr_jupyter_urlbase: "http://example.org"
   - idr_docker_pull_latest: True
   - idr_jupyter_ip: "{{ hostvars[inventory_hostname]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"
-  - idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.1.0"
+  #- idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.1.0"
+  #- idr_jupyter_hub_image: "manics/jupyterhub-githubauth:latest"
+  - idr_jupyter_hub_image: "manics/jupyterhub-githubauth:auth"
   - idr_jupyter_notebook_image: "imagedata/jupyter-docker:0.1.0"
   - idr_jupyter_hub_log_level: DEBUG
   #- idr_jupyter_prefix: "/jupyter"

--- a/ansible/idr-playbooks/idr-docker.yml
+++ b/ansible/idr-playbooks/idr-docker.yml
@@ -16,6 +16,8 @@
 - hosts: "{{ idr_environment | default('idr') }}-docker-hosts"
 
   pre_tasks:
+
+  # This sets a host_var on all docker-hosts which can be used in other plays
   - name: enable/disable docker swarm
     set_fact:
       docker_swarm_enabled: False
@@ -44,6 +46,7 @@
     always_run: yes
     #ignore_errors: yes
     register: docker_swarm_net_mtu
+    when: docker_swarm_enabled
     #changed_when: "(docker_use_ipv4_nic_mtu | default(True)) and
     changed_when: docker_swarm_net_mtu.stdout != "{{ ansible_default_ipv4.mtu }}"
     failed_when: "(docker_swarm_net_mtu.rc != 0) and {{ not docker_swarm_net_mtu.stderr.endswith('No such network: docker_gwbridge') }}"
@@ -53,13 +56,13 @@
     command: docker network rm docker_gwbridge
     register: docker_swarm_net_rm
     failed_when: "(docker_swarm_net_rm.rc != 0) and {{ not docker_swarm_net_rm.stderr.endswith('network docker_gwbridge not found') }}"
-    when: docker_swarm_net_mtu.changed
+    when: docker_swarm_enabled and docker_swarm_net_mtu.changed
 
   # TODO: Make subnet configurable
   - name: docker swarm | network mtu create docker_gwbridge
     become: yes
     command: docker network create --opt com.docker.network.driver.mtu={{ ansible_default_ipv4.mtu }} --subnet 172.18.0.0/16 docker_gwbridge
-    when: docker_swarm_net_mtu.changed
+    when: docker_swarm_enabled and docker_swarm_net_mtu.changed
 
 
 - hosts: "{{ idr_environment | default('idr') }}-dockermanager-hosts"
@@ -121,11 +124,12 @@
       opts: rsize=8192,wsize=8192,timeo=14,intr,rw
       src: "{{ manager_ip }}:/data"
       state: mounted
+    when: docker_swarm_enabled
 
   - name: docker swarm | join worker
     become: yes
     command: docker swarm join --token {{ token }} {{ manager_ip }}
-    when: docker_swarm_active.stdout != 'active'
+    when: docker_swarm_enabled and docker_swarm_active.stdout != 'active'
 
   vars:
     token: "{{ hostvars[groups[idr_environment | default('idr') + '-dockermanager-hosts'][0]]['docker_swarm_worker_token'] }}"
@@ -195,6 +199,8 @@
     command: docker pull "{{ idr_jupyter_notebook_image }}"
     when: docker_image_jhnote.changed
 
+  # Only enable systemd service when not using docker swarm
+
   - name: jupyterhub | create systemd service
     become: yes
     template:
@@ -211,15 +217,89 @@
     become: yes
     service:
       name: docker-jupyterhub.service
-      state: restarted
+      state: "{{ docker_swarm_enabled | ternary('stopped', 'restarted') }}"
     when: jupyterconfig.changed
 
   - name: jupyterhub | enable jupyterhub
     become: yes
     service:
-      enabled: yes
+      enabled: "{{ docker_swarm_enabled | ternary('no', 'yes') }}"
       name: docker-jupyterhub.service
-      state: started
+      state: "{{ docker_swarm_enabled | ternary('stopped', 'started') }}"
+
+
+  # Docker swarm: setup network and start the service
+  # TODO: Use docker_network when we switch to Ansible 2.2
+
+  - name: jupyterhub | check docker swarm network
+    become: yes
+    command: docker network inspect "{{ idr_jupyter_network }}"
+    always_run: yes
+    register: docker_jupyter_net
+    when: docker_swarm_enabled
+    changed_when: "docker_jupyter_net.rc != 0"
+    failed_when: "docker_jupyter_net.rc > 1"
+
+  - name: jupyterhub | create docker swarm network
+    become: yes
+    command: docker network create --driver overlay --subnet "{{ idr_jupyter_subnet }}" "{{ idr_jupyter_network }}"
+    when: docker_swarm_enabled and docker_jupyter_net.changed
+
+  - name: jupyterhub | stop docker jupyter service
+    become: yes
+    command: docker service rm "{{ idr_jupyter_service }}"
+    when: docker_swarm_enabled and jupyterconfig.changed
+    failed_when: False
+
+  - name: jupyterhub | check docker jupyter service
+    become: yes
+    command: docker service inspect "{{ idr_jupyter_service }}"
+    always_run: yes
+    register: docker_jupyter_service
+    when: docker_swarm_enabled
+    changed_when: "docker_jupyter_service.rc != 0"
+    failed_when: "docker_jupyter_service.rc > 1"
+
+  - name: jupyterhub | create docker jupyter service
+    become: yes
+    command: >
+      docker service create
+          --name {{ idr_jupyter_service }}
+          --network {{ idr_jupyter_network }}
+          --log-driver journald
+          -p 8000:8000
+          -p 8081:8081
+          -e DOCKER_HOST=unix://var/run/docker.sock
+          --mount source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind
+          --mount source=/srv/jupyterhub/jupyterhub_config.py,target=/srv/jupyterhub/jupyterhub_config.py,type=bind,readonly=true
+          {{ idr_jupyter_hub_image }}
+          jupyterhub
+          --no-ssl
+          --base-url={{ idr_jupyter_prefix }}
+          -f /srv/jupyterhub/jupyterhub_config.py
+          --log-level={{ idr_jupyter_hub_log_level }}
+    when: docker_swarm_enabled and docker_jupyter_service.changed
+
+  - name: jupyterhub | docker jupyter service script
+    become: yes
+    copy:
+      dest: /docker-jupyter.sh
+      content: >
+            docker service create
+            --name {{ idr_jupyter_service }}
+            --network {{ idr_jupyter_network }}
+            --log-driver journald
+            -p 8000:8000
+            -p 8081:8081
+            -e DOCKER_HOST=unix://var/run/docker.sock
+            --mount source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind
+            --mount source=/srv/jupyterhub/jupyterhub_config.py,target=/srv/jupyterhub/jupyterhub_config.py,type=bind,readonly=true
+            {{ idr_jupyter_hub_image }}
+            jupyterhub
+            --no-ssl
+            --base-url={{ idr_jupyter_prefix }}
+            -f /srv/jupyterhub/jupyterhub_config.py
+            --log-level={{ idr_jupyter_hub_log_level }}
 
   - name: jupyterhub | check if idr-notebooks repo exists
     stat:
@@ -257,6 +337,10 @@
                 PASSWORD = "{{ idr_jupyter_omero_pass | quote }}"
 
   vars:
+  - idr_jupyter_service: omero-jupyter
+  - idr_jupyter_network: omero-jupyter-net
+  - idr_jupyter_subnet: "172.21.0.0/16"
+  - idr_jupyter_authenticator: "oauthenticator.GitHubOAuthenticator"
   #- idr_jupyter_urlbase: "http://example.org"
   - idr_docker_pull_latest: True
   - idr_jupyter_ip: "{{ hostvars[inventory_hostname]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"

--- a/ansible/idr-playbooks/idr-docker.yml
+++ b/ansible/idr-playbooks/idr-docker.yml
@@ -10,6 +10,8 @@
 #     docker network rm docker_gwbridge
 #     docker network create --opt com.docker.network.driver.mtu=1400 --subnet 172.18.0.0/16 docker_gwbridge
 
+# TODO: Convert this into one or more roles
+
 
 - hosts: "{{ idr_environment | default('idr') }}-docker-hosts"
 

--- a/ansible/idr-playbooks/idr-docker.yml
+++ b/ansible/idr-playbooks/idr-docker.yml
@@ -3,6 +3,13 @@
 
 # TODO: Convert this into one or more roles
 
+# TODO: Docker uses an incorrect MTU on OpenStack VMs, and it is not possible
+# to easily set it on the swarm ingress network. See this workround:
+# https://github.com/docker/docker/issues/24906#issuecomment-235894478
+# This must be done before creating the swarm
+#     docker network rm docker_gwbridge
+#     docker network create --opt com.docker.network.driver.mtu=1400 --subnet 172.18.0.0/16 docker_gwbridge
+
 
 - hosts: "{{ idr_environment | default('idr') }}-docker-hosts"
 
@@ -26,6 +33,31 @@
     ignore_errors: yes
     register: docker_swarm_active
     changed_when: False
+
+  # TODO: Maybe check docker_use_ipv4_nic_mtu?
+  # TODO: Use docker_network when we switch to Ansible 2.2
+  - name: docker swarm | check mtu
+    become: yes
+    command: docker network inspect docker_gwbridge -f "{{ '{{' }} index .Options \"com.docker.network.driver.mtu\" {{ '}}' }}"
+    always_run: yes
+    #ignore_errors: yes
+    register: docker_swarm_net_mtu
+    #changed_when: "(docker_use_ipv4_nic_mtu | default(True)) and
+    changed_when: docker_swarm_net_mtu.stdout != "{{ ansible_default_ipv4.mtu }}"
+    failed_when: "(docker_swarm_net_mtu.rc != 0) and {{ not docker_swarm_net_mtu.stderr.endswith('No such network: docker_gwbridge') }}"
+
+  - name: docker swarm | network mtu delete docker_gwbridge
+    become: yes
+    command: docker network rm docker_gwbridge
+    register: docker_swarm_net_rm
+    failed_when: "(docker_swarm_net_rm.rc != 0) and {{ not docker_swarm_net_rm.stderr.endswith('network docker_gwbridge not found') }}"
+    when: docker_swarm_net_mtu.changed
+
+  # TODO: Make subnet configurable
+  - name: docker swarm | network mtu create docker_gwbridge
+    become: yes
+    command: docker network create --opt com.docker.network.driver.mtu={{ ansible_default_ipv4.mtu }} --subnet 172.18.0.0/16 docker_gwbridge
+    when: docker_swarm_net_mtu.changed
 
 
 - hosts: "{{ idr_environment | default('idr') }}-dockermanager-hosts"

--- a/ansible/idr-playbooks/idr-docker.yml
+++ b/ansible/idr-playbooks/idr-docker.yml
@@ -201,24 +201,6 @@
     when: docker_image_jhnote.changed
 
 
-  # Docker swarm: setup network
-  # TODO: Use docker_network in Ansible 2.2
-
-  - name: jupyterhub | check docker swarm network
-    become: yes
-    command: docker network inspect "{{ idr_jupyter_network }}"
-    always_run: yes
-    register: docker_jupyter_net
-    when: docker_swarm_enabled
-    changed_when: "docker_jupyter_net.rc != 0"
-    failed_when: "docker_jupyter_net.rc > 1"
-
-  - name: jupyterhub | create docker swarm network
-    become: yes
-    command: docker network create --driver overlay "{{ idr_jupyter_network }}"
-    when: docker_swarm_enabled and docker_jupyter_net.changed
-
-
   # Without Docker swarm: start and enable the service
 
   - name: jupyterhub | create systemd service
@@ -267,7 +249,7 @@
 
   - name: jupyterhub | create docker swarm network
     become: yes
-    command: docker network create --driver overlay "{{ idr_jupyter_network }}"
+    command: docker network create --driver overlay "{{ idr_jupyter_network }}" --opt com.docker.network.driver.mtu={{ ansible_default_ipv4.mtu }}
     when: docker_swarm_enabled and docker_jupyter_net.changed
 
   - name: jupyterhub | create swarm systemd service


### PR DESCRIPTION
This updates the IDR docker playbook to run containers on Docker Swarm. At the moment this requires custom changes to
- Docker Spawner: https://github.com/jupyterhub/dockerspawner/compare/master...manics:master
  Docker 1.12 only supports Swarm mode for services (Note Docker 1.13 should support running normal containers in the swarm https://github.com/docker/docker/pull/25962 https://github.com/jupyterhub/dockerspawner/issues/117#issuecomment-255141210)
- Several networking MTU workarounds
- Also note that the main JupyterHub server is run as a Docker service, which potentially conflicts with Systemd since Docker service will automatically start/restart it
