### PR TITLE
upgrade django-redis

### DIFF
--- a/ansible/idr-playbooks/files/IDR-OMERO-52-omero.j2
+++ b/ansible/idr-playbooks/files/IDR-OMERO-52-omero.j2
@@ -44,7 +44,7 @@ config set omero.web.session_cookie_age 3600
 
 # redis
 config set omero.web.session_engine "django.contrib.sessions.backends.cache"
-config set omero.web.caches '{"default": {"BACKEND": "redis_cache.RedisCache","LOCATION": "127.0.0.1:6379"}}'
+config set omero.web.caches '{"default": {"BACKEND": "django_redis.cache.RedisCache","LOCATION": "redis://127.0.0.1:6379/0"}}'
 
 # social media
 config set omero.web.sharing.twitter '{"omero": "@openmicroscopy"}'

--- a/ansible/roles/omero-web-runtime/tasks/main.yml
+++ b/ansible/roles/omero-web-runtime/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: omero-web | install django redis requirements
   become: yes
   pip:
-    name: "django-redis-cache>=1.6.5"
+    name: "django-redis>=4.4"
     state: present
   when: omero_web_runtime_redis
 


### PR DESCRIPTION
When using redis we have to use newer supported package https://trello.com/c/GIJQA0kg/177-redis-out-of-experimental
