### PR TITLE
System upgrade fixes

### DIFF
--- a/ansible/roles/upgrade-distpackages/tasks/main.yml
+++ b/ansible/roles/upgrade-distpackages/tasks/main.yml
@@ -6,6 +6,7 @@
   yum:
     name: "{{ item }}"
     state: latest
+    update_cache: yes
   with_items: "{{ upgrade_distpackages }}"
 
 - name: system | current running kernel


### PR DESCRIPTION
- Force a yum cache refresh. Today's patching showed that the cache isn't always updated before instaling updates.