### PR TITLE
Sphinx build role

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -43,6 +43,14 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "docs" do |samba|
+    samba.vm.box = "centos/7"
+    samba.vm.provision "ansible" do |ansible|
+      ansible.verbose = "v"
+      ansible.playbook = "test.yml"
+    end
+  end
+
   config.vm.define "cliutils" do |cliutils|
     cliutils.vm.box = "centos/7"
     cliutils.vm.provision "ansible" do |ansible|

--- a/ansible/ci-deployment.yml
+++ b/ansible/ci-deployment.yml
@@ -36,4 +36,5 @@
 # Deploy Documentation prerequisites
 - hosts: ci-docs
   roles:
+    - role: sphinx-build
     - role: ansible

--- a/ansible/ci-deployment.yml
+++ b/ansible/ci-deployment.yml
@@ -37,4 +37,3 @@
 - hosts: ci-docs
   roles:
     - role: ansible
-    - role: texlive

--- a/ansible/roles/python-devel/tasks/main.yml
+++ b/ansible/roles/python-devel/tasks/main.yml
@@ -14,7 +14,6 @@
     state: present
   with_items:
     - python-devel
-    - gcc
 
 - name: virtualenv | install python tools
   become: yes

--- a/ansible/roles/sphinx-build/README.md
+++ b/ansible/roles/sphinx-build/README.md
@@ -1,0 +1,14 @@
+Sphinx documentation build
+==========================
+
+Documentation build dependencies.
+
+Requirements
+------------
+
+Depends on python.
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/sphinx-build/meta/main.yml
+++ b/ansible/roles/sphinx-build/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- { role: python-devel }

--- a/ansible/roles/sphinx-build/tasks/main.yml
+++ b/ansible/roles/sphinx-build/tasks/main.yml
@@ -3,6 +3,7 @@
 
 
 - name: Sphinx documentation packages | pip install packages
+  become: yes
   pip:
     name: "{{ item.name }}"
     state: present

--- a/ansible/roles/sphinx-build/tasks/main.yml
+++ b/ansible/roles/sphinx-build/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# tasks file for roles/sphinx-build
+
+
+- name: Sphinx documentation packages | pip install packages
+  pip:
+    name: "{{ item.name }}"
+    state: present
+    version: "{{ item.version }}"
+  with_items:
+    - name: sphinx
+      version: 1.2.3

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -73,3 +73,7 @@
       # Everything except the UID
       - "pg_alice.stdout.startswith('alice|f|t|f|f|f|t|f|-1|********|||')"
       - "pg_bob.stdout.startswith('bob|f|t|f|t|f|t|f|-1|********|||')"
+
+- hosts: docs
+  roles:
+  - role: sphinx-build

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -77,3 +77,11 @@
 - hosts: docs
   roles:
   - role: sphinx-build
+
+  tasks:
+  - command: sphinx-build --version
+    register: sphinx_version
+
+  - assert:
+      that:
+      - "sphinx_version.stdout == 'Sphinx (sphinx-build) 1.2.3'"


### PR DESCRIPTION
This is a minimal port of the changes proposed https://github.com/openmicroscopy/infrastructure/pull/20 in the context of the upcoming Bio-Formats 5.3.0-m1 release preparation.

This PR puts the minimal requirements into place for documentation nodes, i.e. installing Sphinx as a dependency. As discussed previously, Sphinx is installed globally instead of within a virtual environment to allow it to be consumed by the Jenkins Ant targets which cannot activate a virtual environment. It also applies the policy of dropping the PDF in favor of ZIPs of the HTML and removes the `texlive` step from the `ci-deployment` playbook. /cc @jburel 
