### PR TITLE
Fix deprecated usage of undefined docker var

### DIFF
--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -38,6 +38,7 @@ Optional variables:
 - `docker_groupmembers`: A list of users who will be added to the `docker` system group, allows docker to be run without sudo
 - `docker_use_ipv4_nic_mtu`: Force Docker to use the MTU set by the main IPV4 interface. This may be necessary on virtualised hosts, see comment in `defaults/main.yml`.
 - `docker_repo_version`: Use a different upstream Docker release branch e.g. `testing`, do not change this unless you know what you are doing
+- `docker_groupmembers`: List of non-admin users who can run `docker`
 
 
 Dependencies

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -26,3 +26,6 @@ docker_use_ipv4_nic_mtu: False
 
 # Upstream Docker release branch
 docker_repo_version: main
+
+# Users who can run docker
+docker_groupmembers: []

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -66,4 +66,3 @@
     groups: docker
     append: yes
   with_items: "{{ docker_groupmembers }}"
-  when: docker_groupmembers is defined


### PR DESCRIPTION
As @aleksandra-tarkowska discovered in #149 Ansible 2.2 drops the previously deprecated usage of undefined vars. This fixes the docker role.

Closes #160