### PR TITLE
Download nginx from https location

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: system packages | setup upstream nginx repo
   become: yes
   yum:
-    name: http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm
+    name: https://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm
     state: present
 
 - name: system packages | install nginx


### PR DESCRIPTION
I updated VirtualBox and was unable to download http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm when running vagrant. I've no idea if it's a VirtualBox/OS X problem, or a change by nginx.org, but using `https` instead seemed to fix it. In any case using `https` should be more secure.