### PR TITLE
Add openstack provider to Vagrantfile

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -11,6 +11,22 @@ Vagrant.configure(2) do |config|
     vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 
+  config.vm.provider :openstack do |os|
+    config.ssh.username = "centos"
+    # Workaround sudo restriction
+    config.ssh.pty = true
+
+    os.openstack_auth_url = "#{ENV['OS_AUTH_URL']}"
+    os.username = "#{ENV['OS_USERNAME']}"
+    os.password = "#{ENV['OS_PASSWORD']}"
+    os.tenant_name = "#{ENV['OS_TENANT_NAME']}"
+    os.region = "#{ENV['OS_REGION_NAME']}"
+
+    os.flavor = 'm1.small'
+    os.image = 'CentOS 7 1607'
+    os.floating_ip_pool = 'external_network'
+  end
+
   config.vm.define "docker" do |docker|
     docker.vm.box = "centos/7"
     docker.vm.provision "ansible" do |ansible|


### PR DESCRIPTION
Allow you to test vagrant boxes on openstack, useful if you upgrade VirtualBox and discover it's broken.

```
vagrant plugin install vagrant-openstack-provider
source openrc.sh
vagrant up --provider openstack BOXNAME ...
```