### PR TITLE
Use OS_CLOUD env in dynamic inventory if set

### DIFF
--- a/ansible/inventory/openstack-private.py
+++ b/ansible/inventory/openstack-private.py
@@ -126,6 +126,7 @@ def append_hostvars(hostvars, groups, key, server, namegroup=False):
 
     hostvars[key] = dict(
         ansible_ssh_host=ansible_ssh_host,
+        ansible_host=ansible_ssh_host,
         openstack=server)
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)

--- a/ansible/inventory/openstack-private.py
+++ b/ansible/inventory/openstack-private.py
@@ -227,6 +227,11 @@ def main():
                     'expand_hostvars': True,
                 }
             ))
+        # shade.inventory ignores OS_CLOUD
+        # http://git.openstack.org/cgit/openstack-infra/shade/tree/shade/inventory.py?h=1.12.1#n38
+        cloud = os.getenv('OS_CLOUD')
+        if cloud:
+            inventory_args['cloud'] = cloud
 
         inventory = shade.inventory.OpenStackInventory(**inventory_args)
 

--- a/ansible/inventory/openstack.py
+++ b/ansible/inventory/openstack.py
@@ -219,6 +219,11 @@ def main():
                     'expand_hostvars': True,
                 }
             ))
+        # shade.inventory ignores OS_CLOUD
+        # http://git.openstack.org/cgit/openstack-infra/shade/tree/shade/inventory.py?h=1.12.1#n38
+        cloud = os.getenv('OS_CLOUD')
+        if cloud:
+            inventory_args['cloud'] = cloud
 
         inventory = shade.inventory.OpenStackInventory(**inventory_args)
 

--- a/ansible/inventory/openstack.py
+++ b/ansible/inventory/openstack.py
@@ -115,6 +115,7 @@ def get_host_groups(inventory, refresh=False):
 def append_hostvars(hostvars, groups, key, server, namegroup=False):
     hostvars[key] = dict(
         ansible_ssh_host=server['interface_ip'],
+        ansible_host=server['interface_ip'],
         openstack=server)
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)


### PR DESCRIPTION
`OS_CLOUD` is one of the standard os-client-config environment variables that can be used to select a single cloud with the openstack CLI e.g. `OS_CLOUD=omedev openstack server list`, but it's ignored by the `shade.inventory` module. This adds it to the dynamic openstack inventories so it can be used with ansible.

E.g. `OS_CLOUD=omedev ansible-playbook -i inventory/openstack.py playbook.yml`