### PR TITLE
Remove redundancy in Vagrantfile test.yml definitions

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -27,65 +27,21 @@ Vagrant.configure(2) do |config|
     os.floating_ip_pool = 'external_network'
   end
 
-  config.vm.define "docker" do |docker|
-    docker.vm.box = "centos/7"
-    docker.vm.provision "ansible" do |ansible|
-      ansible.verbose = "v"
-      ansible.playbook = "test.yml"
-    end
-  end
-
-  config.vm.define "postgres" do |postgres|
-    postgres.vm.box = "centos/7"
-    postgres.vm.provision "ansible" do |ansible|
-      ansible.verbose = "v"
-      ansible.playbook = "test.yml"
-    end
-  end
-
-  config.vm.define "redis" do |redis|
-    redis.vm.box = "centos/7"
-    redis.vm.provision "ansible" do |ansible|
-      ansible.verbose = "v"
-      ansible.playbook = "test.yml"
-    end
-  end
-
-  config.vm.define "samba" do |samba|
-    samba.vm.box = "centos/7"
-    samba.vm.provision "ansible" do |ansible|
-      ansible.verbose = "v"
-      ansible.playbook = "test.yml"
-    end
-  end
-
-  config.vm.define "docs" do |samba|
-    samba.vm.box = "centos/7"
-    samba.vm.provision "ansible" do |ansible|
-      ansible.verbose = "v"
-      ansible.playbook = "test.yml"
-    end
-  end
-
-  config.vm.define "cliutils" do |cliutils|
-    cliutils.vm.box = "centos/7"
-    cliutils.vm.provision "ansible" do |ansible|
-      ansible.verbose = "v"
-      ansible.playbook = "test.yml"
-    end
-  end
-
-  config.vm.define "selinux" do |selinux|
-    selinux.vm.box = "centos/7"
-    selinux.vm.provision "ansible" do |ansible|
-      ansible.playbook = "test.yml"
-    end
-  end
-
-  config.vm.define "jupyter" do |jupyter|
-    jupyter.vm.box = "centos/7"
-    jupyter.vm.provision "ansible" do |ansible|
-      ansible.playbook = "test.yml"
+  [
+    "cliutils",
+    "docker",
+    "docs",
+    "jupyter",
+    "postgres",
+    "redis",
+    "samba",
+    "selinux",
+  ].each do |server|
+    config.vm.define "#{server}" do |node|
+      node.vm.box = "centos/7"
+      node.vm.provision "ansible" do |ansible|
+        ansible.playbook = "test.yml"
+      end
     end
   end
 


### PR DESCRIPTION
Replace 8 identical server definitions with a loop. Removed Ansible verbose output so it's easier to check the output, there should be no other change in behaviour or usage of vagrant.