### PR TITLE
Bump default devspace version to 0.3.4

### DIFF
--- a/ansible/roles/devspace/defaults/main.yml
+++ b/ansible/roles/devspace/defaults/main.yml
@@ -10,7 +10,7 @@ snoopy_dir_path: ""
 # devspace source
 devspace_git_repo: "https://github.com/openmicroscopy/devspace.git"
 # devspace branch
-devspace_git_repo_version: "0.3.3"
+devspace_git_repo_version: "0.3.4"
 
 # devspace user
 devspace_user: omero


### PR DESCRIPTION
This should include the bug fix for handling submodules in the OMERO build /cc @aleksandra-tarkowska 