### PR TITLE
Network basic interface addition (IDR-0.3.0)

### DIFF
--- a/ansible/roles/network/README.md
+++ b/ansible/roles/network/README.md
@@ -13,6 +13,13 @@ Role Variables
 - `network_disable_ifaces`: A list of network device names to be explicitly disabled, use this if you want to be sure the interface is disabled (as opposed to being auto-configured by the system).
 - `network_delete_ifaces`: A regular expression describing the network device name(s) to be removed (note this means the system may auto-configure them), use this for cleaning up spare configuration files.
 
+The above variables provide full control of all network interfaces on a server, and will almost always require a restart of the network service on the server.
+
+For convenience an alternative variable for adding interfaces with very simple configuration is available that will restart only the added interface.
+This should only be used where it is critical that connections to existing NICs are maintained, and is not recommended since the state of the system may not match the state after a full restart.
+- `network_basic_ifaces`: Adds and restart individual interfaces, use `network_ifaces` unless you really need this.
+
+
 
 Example Playbook
 ----------------

--- a/ansible/roles/network/tasks/add_basic_ifaces.yml
+++ b/ansible/roles/network/tasks/add_basic_ifaces.yml
@@ -1,0 +1,24 @@
+---
+# Add new simple network interfaces
+# This is intended to allow you to add an interface to a server without a
+# full network restart.
+
+- name: network | setup basic nics
+  become: yes
+  template:
+    src: etc-sysconfig-network-scripts-ifcfg.j2
+    dest: /etc/sysconfig/network-scripts/ifcfg-{{ item.device }}
+  with_items: "{{ network_basic_ifaces | default([]) }}"
+  register: network_ifaces_modified
+
+- debug:
+    msg: "{{ item }}"
+  with_items:
+  - "{{ network_ifaces_modified.results }}"
+
+- name: network | restart modified nics
+  become: yes
+  shell: "/usr/sbin/ifdown {{ item.item.device }} && /usr/sbin/ifup {{ item.item.device }}"
+  when: "{{ item | changed }}"
+  with_items:
+  - "{{ network_ifaces_modified.results }}"

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -61,3 +61,6 @@
   # 'skipped' field may be missing if it wasn't skipped
   when: not item.skipped | default (False)
   with_items: "{{ checkbonds.results }}"
+
+- include: add_basic_ifaces.yml
+  when: "{{ network_basic_ifaces | default([]) }}"

--- a/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/ansible/roles/network/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -9,10 +9,8 @@ IPV6INIT={{ item.ipv6init }}
 {% else %}
 IPV6INIT=yes
 {% endif %}
-{% if 'mtu' in item %}
+{% if 'mtu' in item and item['mtu'] %}
 MTU={{ item.mtu }}
-{% else %}
-MTU=1500
 {% endif %}
 ONBOOT=yes
 {% if 'networkmanager' in item %}


### PR DESCRIPTION
- Adds a tasks for adding a single NIC without any fancy configuration
  - This was required because a full network restart was causing problems on one of the IDR instances. This addition should only be used where unavoidable.
- Allows the MTU to be unset (i.e. managed by the system).