### PR TITLE
Openstack dynamic inventory: store and detect SSH proxy (IDR-0.3.0)

### DIFF
--- a/ansible/inventory/openstack-private.py
+++ b/ansible/inventory/openstack-private.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
 # Copyright (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
 # Copyright (c) 2015, Hewlett-Packard Development Company, L.P.
+# Copyright (C) 2016, University of Dundee & Open Microscopy Environment
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/ansible/inventory/openstack-private.py
+++ b/ansible/inventory/openstack-private.py
@@ -39,6 +39,14 @@
 # use_hostnames changes the behavior from registering every host with its UUID
 #               and making a group of its hostname to only doing this if the
 #               hostname in question has more than one server
+#
+# This dynamic inventory has been modified from the upstream version:
+# - It always returns private IPs for servers.
+# - If the server metadata contains `ssh_proxy_host` this will be used to
+#   automatically find a SSH proxy server and sets a host-var
+#   `ansible_ssh_common_args` on the server.
+# - If the server metadata contains `network_order` these networks will be
+#   searched for a private IP in that order.
 
 import argparse
 import collections

--- a/ansible/inventory/openstack-private.py
+++ b/ansible/inventory/openstack-private.py
@@ -253,7 +253,9 @@ def get_host_groups_from_cloud(inventory):
                         hostvars, groups, server['id'], server,
                         namegroup=True)
 
-    update_ssh_proxy_host(hostvars)
+    auto_proxy = os.getenv('OS_PROXY_DISCOVER')
+    if auto_proxy and auto_proxy != '0':
+        update_ssh_proxy_host(hostvars)
     groups['_meta'] = {'hostvars': hostvars}
     return groups
 


### PR DESCRIPTION
Use optional metadata properties on OpenStack instances to:
1. Automatically set an SSH proxy host
   - If the env-var `OS_PROXY_DISCOVER=1` and property `ssh_proxy_host` is set on the instance:
     - `ssh_proxy_host=proxy` indicates this instance should be used as a SSH proxy for any instances connected to the same network
     - `ssh_proxy_host=required` means attempt to find an instance on the same network with `ssh_proxy_host=proxy` and if found set the host-variable `ansible_ssh_common_args` with `ProxyCommand`, unless that hostvar already has a value.
   - The env-var is required to avoid surprising people who use this dynamic inventory without being aware of the extra features.
2. Return networks in the original order
   - The OpenStack dynamic inventory returns the list of networks that an instance is attached to as a dictionary, so it is not possible to retrieve the order that the networks were defined as at creation time. If the property `network_order` is set then this must be a comma separated list of network names in order.

Use in conjunction with changes to `roles/openstack-idr-instances` in https://github.com/openmicroscopy/infrastructure/pull/177


