### PR TITLE
Name fields in `omero.web.ui.top_links` (omero-web-apps role) (IDR-0.3.0)

### DIFF
--- a/ansible/roles/omero-web-apps/README.md
+++ b/ansible/roles/omero-web-apps/README.md
@@ -28,7 +28,7 @@ All variables are optional, see `defaults/main.yml` for the full list
 - `omero_web_app_add_top_links`: Lists of top link dictionaries to be included in `omero.web.ui.top_links`, of the form:
   - `label`: Label
   - `link`: URL or a dict
-  - `attrs`: Dictionary of attributes
+  - `attrs`: Dictionary of attributes (optional)
 
 
 Example

--- a/ansible/roles/omero-web-apps/README.md
+++ b/ansible/roles/omero-web-apps/README.md
@@ -25,6 +25,10 @@ All variables are optional, see `defaults/main.yml` for the full list
 - `omero_web_apps_add`: List of web application names to be included in `omero.web.apps`
 - `omero_web_app_add_top_links`: Dictionary of lists to be included in `omero.web.ui.top_links`.
   This must be a YAML object, which will be auto-converted to JSON.
+- `omero_web_app_add_top_links`: Lists of top link dictionaries to be included in `omero.web.ui.top_links`, of the form:
+  - `label`: Label
+  - `link`: URL or a dict
+  - `attrs`: Dictionary of attributes
 
 
 Example

--- a/ansible/roles/omero-web-apps/tasks/main.yml
+++ b/ansible/roles/omero-web-apps/tasks/main.yml
@@ -33,7 +33,7 @@
   command: >
     {{ omero_web_omero }} config append --set --report
     omero.web.ui.top_links
-    {{ [item.label, item.link, item.attrs] | to_json | quote }}
+    {{ [item.label, item.link, (item.attrs | default({}))] | to_json | quote }}
   register: out
   changed_when: "'Changed:' in out.stdout"
   with_items: "{{ omero_web_app_add_top_links | default([]) }}"

--- a/ansible/roles/omero-web-apps/tasks/main.yml
+++ b/ansible/roles/omero-web-apps/tasks/main.yml
@@ -33,9 +33,9 @@
   command: >
     {{ omero_web_omero }} config append --set --report
     omero.web.ui.top_links
-    {{ item.value | to_json | quote }}
+    {{ [item.label, item.link, item.attrs] | to_json | quote }}
   register: out
   changed_when: "'Changed:' in out.stdout"
-  with_dict: "{{ omero_web_app_add_top_links | default({}) }}"
+  with_items: "{{ omero_web_app_add_top_links | default([]) }}"
   notify:
     - restart omero-web


### PR DESCRIPTION
The tuples that go into `omero.web.ui.top_links` are a bit of a mystery at first. This PR modifies the `omero-web-apps` role so that each of the tuple elements is named.

These field names are based on the code in https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroWeb/omeroweb/webclient/decorators.py#L162 (I couldn't find any other docs)