### PR TITLE
IDR hostgroup naming (IDR-0.3.0)

### DIFF
--- a/ansible/idr-playbooks/idr-dundee-nfs.yml
+++ b/ansible/idr-playbooks/idr-dundee-nfs.yml
@@ -2,7 +2,9 @@
 # The default is to use NFS, if you are using samba you must install the
 # dependencies (cifs-utils) yourself.
 
-- hosts: "{{ idr_environment | default('idr') }}-uod-nfs"
+- hosts: >
+    {{ idr_environment | default('idr') }}-uod-nfs
+    {{ idr_environment | default('idr') }}-a-uod-nfs
 
   vars:
     idr_mountpoint: /uod/idr

--- a/ansible/idr-playbooks/idr-local-users.yml
+++ b/ansible/idr-playbooks/idr-local-users.yml
@@ -2,7 +2,9 @@
 # Playbook for creating local user accounts on Openstack instances
 
 # Variables should be in a private group_vars file
-- hosts: "{{ idr_environment | default('idr') }}-database-hosts, {{ idr_environment | default('idr') }}-omero-hosts, {{ idr_environment | default('idr') }}-proxy-hosts"
+- hosts: >
+    {{ idr_environment | default('idr') }}-hosts
+    management-hosts
   roles:
   - role: sudoers
 #    sudoers_individual_commands:

--- a/ansible/idr-playbooks/idr-local-users.yml
+++ b/ansible/idr-playbooks/idr-local-users.yml
@@ -4,6 +4,7 @@
 # Variables should be in a private group_vars file
 - hosts: >
     {{ idr_environment | default('idr') }}-hosts
+    {{ idr_environment | default('idr') }}-a-hosts
     management-hosts
   roles:
   - role: sudoers

--- a/ansible/idr-playbooks/idr-omero.yml
+++ b/ansible/idr-playbooks/idr-omero.yml
@@ -12,7 +12,9 @@
 # - `idr_net_iface=iface` if your servers use a network interface other
 #   then eth0 for inter-machine networking
 
-- hosts: "{{ idr_environment | default('idr') }}-database-hosts"
+- hosts: >
+    {{ idr_environment | default('idr') }}-database-hosts
+    {{ idr_environment | default('idr') }}-a-database-hosts
 
   roles:
   - role: postgresql

--- a/ansible/idr-playbooks/os-idr-volumes.yml
+++ b/ansible/idr-playbooks/os-idr-volumes.yml
@@ -1,13 +1,17 @@
 ---
 # Initialise openstack volumes from inside VMs if necessary
 
-- hosts: "{{ idr_environment | default('idr') }}-database-hosts"
+- hosts: >
+    {{ idr_environment | default('idr') }}-database-hosts
+    {{ idr_environment | default('idr') }}-a-database-hosts
   roles:
   - role: storage-volume-initialise
     storage_volume_initialise_device: "{{ database_db_vol_dev | default('/dev/vdb') }}"
     storage_volume_initialise_mount: /var/lib/pgsql
 
-- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+- hosts: >
+    {{ idr_environment | default('idr') }}-omero-hosts
+    {{ idr_environment | default('idr') }}-a-omero-hosts
   roles:
   - role: storage-volume-initialise
     storage_volume_initialise_device: "{{ omero_data_vol_dev | default('/dev/vdb') }}"
@@ -20,7 +24,9 @@
     storage_volume_initialise_mount: /var/cache/nginx
 
 # Use this group for any other IDR VMs that should have a volume mounted on /data
-- hosts: "{{ idr_environment | default('idr') }}-data-hosts"
+- hosts: >
+    {{ idr_environment | default('idr') }}-data-hosts
+    {{ idr_environment | default('idr') }}-a-data-hosts
   roles:
   - role: storage-volume-initialise
     storage_volume_initialise_device: "{{ data_vol_dev | default('/dev/vdb') }}"


### PR DESCRIPTION
The current DIR hostgroup environment naming strategy:
- IDR production instances are in group `{{ idr_environment }}-*hosts`
- IDR analysis instances are in group `{{ idr_environment }}-a*hosts`
