### PR TITLE
Fix the EBI NFS playbook (IDR-0.3.0)

### DIFF
--- a/ansible/idr-playbooks/idr-ebi-nfs.yml
+++ b/ansible/idr-playbooks/idr-ebi-nfs.yml
@@ -1,28 +1,19 @@
 # Self-contained Ansible playbook for setting up the Embassy IDR NFS shares
-- hosts: ebi-nfs
+- hosts: >
+    {{ idr_environment | default('idr') }}-ebi-nfs
+    {{ idr_environment | default('idr') }}-a-ebi-nfs
+
+  roles:
+
+  # The NFS network
+  - role: network
+    network_basic_ifaces:
+    - device: eth1
+      bootproto: dhcp
+      mtu:
+      type: Ethernet
 
   tasks:
-
-  # TODO: Use network role instead
-  - name: Setup eth1
-    become: yes
-    copy:
-      content: |
-        DEVICE="eth1"
-        BOOTPROTO="dhcp"
-        ONBOOT="yes"
-        TYPE="Ethernet"
-        USERCTL="yes"
-        PEERDNS="yes"
-        IPV6INIT="no"
-        PERSISTENT_DHCLIENT="1"
-      dest: /etc/sysconfig/network-scripts/ifcfg-eth1
-    register: eth1
-
-  - name: Start eth1
-    become: yes
-    command: /usr/sbin/ifup eth1
-    when: eth1.changed
 
   - name: Create NFS group
     become: yes

--- a/ansible/idr-playbooks/idr-ebi-nfs.yml
+++ b/ansible/idr-playbooks/idr-ebi-nfs.yml
@@ -35,7 +35,7 @@
     mount:
       fstype: nfs
       name: "{{ nfs_mountpoint }}"
-      opts: rsize=8192,wsize=8192,timeo=14,intr
+      opts: rsize=8192,wsize=8192,timeo=14,intr,nolock
       src: 10.35.106.250:/ivol_bioimage_sm
       state: mounted
 


### PR DESCRIPTION
This includes adding `nolock` to the NFS mount options (not sure why it's required, but it failed without it), and using a modified network role to setup the second NIC.