### PR TITLE
Remove non-specific management-hosts from idr-local-users.yml (IDR-0.3.0)

### DIFF
--- a/ansible/idr-playbooks/idr-local-users.yml
+++ b/ansible/idr-playbooks/idr-local-users.yml
@@ -5,7 +5,6 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-hosts
     {{ idr_environment | default('idr') }}-a-hosts
-    management-hosts
   roles:
   - role: sudoers
 #    sudoers_individual_commands:


### PR DESCRIPTION
Minor cleanup, the management VM is in `{{ idr_environment }}-hosts` so doesn't need to be specified separately.