### PR TITLE
Add haproxy to requirements.yml, add example (IDR-0.3.1)

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -47,6 +47,7 @@ Vagrant.configure(2) do |config|
   end
 
   [
+    "haproxy",
     "omero-server",
   ].each do |server|
     config.vm.define "#{server}" do |node|

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -7,3 +7,7 @@
 - name: munin-node
   src: https://github.com/openmicroscopy/ansible-role-munin-node.git
   version:  1.2.1-openmicroscopy1
+
+- name: haproxy
+  src: https://github.com/openmicroscopy/ansible-role-haproxy.git
+  version: origin/master

--- a/ansible/tests/haproxy.yml
+++ b/ansible/tests/haproxy.yml
@@ -1,0 +1,33 @@
+- hosts: haproxy
+
+  roles:
+
+  - role: selinux-utils
+  - role: haproxy
+    haproxy_frontends:
+    - name: frontend-web
+      address: '*:80'
+      mode: http
+      backend: backend-web
+    - name: frontend-ssh
+      address: '*:10022'
+      mode: tcp
+      backend: backend-ssh
+    haproxy_backends:
+    - name: backend-web
+      mode: http
+      balance_method: roundrobin
+      servers:
+      - name: backend-web-1
+        address: www.openmicroscopy.org:80
+      - name: backend-web-2
+        address: idr-demo.openmicroscopy.org:80
+        options:
+        - forwardfor
+        - httpchk GET /about/
+        cookie: "SERVERID insert indirect"
+    - name: backend-ssh
+      mode: tcp
+      servers:
+      - name: backend-ssh-1
+        address: 10.0.0.1:22


### PR DESCRIPTION
This depends on https://github.com/openmicroscopy/ansible-role-haproxy.git which doesn't currently exist, so for initial testing you'll have to change that line in `requirements.yml` to https://github.com/manics/ansible-role-haproxy (currently in process of being transferred to @joshmoore)