### PR TITLE
Add role for adding openstack networks to existing instances (IDR-0.3.1)

### DIFF
--- a/ansible/roles/openstack-idr-instance-network/README.md
+++ b/ansible/roles/openstack-idr-instance-network/README.md
@@ -1,0 +1,45 @@
+Openstack IDR Instance Network
+==============================
+
+Add one or more networks to an existing OpenStack instance.
+
+
+Dependencies
+------------
+
+This currently requires the `nova` command line client to be in your path.
+At the time of writing the `openstack` client doesn't support adding interfaces to existing instances.
+
+
+Role Variables
+--------------
+
+Required variables:
+- `idr_instance_network_server`: The instance to be modified
+- `idr_instance_network_networks`: A list of networks the server should be connected to.
+  If the instance is connected to other networks which aren't in this list they *won't* be removed from the server.
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+      - role: openstack-idr-instance-network
+        idr_instance_network_server: idr-gateway-server
+        idr_instance_network_networks:
+        - existing-network
+        - new-network-1
+
+    # After connecting the network to the instance you may want to initialise
+    # the corresponding NIC inside the instance. For example (this will not
+    # affect existing NICs):
+    - hosts: idr-gateway-server
+      roles:
+      - role: network-cloud-interfaces
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles/openstack-idr-instance-network/tasks/main.yml
+++ b/ansible/roles/openstack-idr-instance-network/tasks/main.yml
@@ -1,0 +1,37 @@
+# Add networks to an existing instance
+#
+
+- name: idr vm | get openstack servers
+  os_server_facts:
+  always_run: yes
+
+- name: idr vm | get openstack networks
+  os_networks_facts:
+  always_run: yes
+
+- debug:
+    msg: >
+      {{ (openstack_servers |
+           selectattr("name", "equalto", idr_instance_network_server) | list)
+           .0.networks }}
+    verbosity: 1
+
+- debug:
+    msg: >
+      {{ (openstack_networks | selectattr("name", "equalto", item) | list)
+      }}
+    verbosity: 1
+  with_items:
+  - "{{ idr_instance_network_networks }}"
+
+- name: idr vm | attach instance to network
+  command: >
+    nova interface-attach
+      --net-id {{ (openstack_networks |
+        selectattr("name", "equalto", item) | list).0.id }}
+      {{ idr_instance_network_server }}
+  when: >
+    item not in ((openstack_servers |
+      selectattr("name", "equalto", idr_instance_network_server) | list).0.networks)
+  with_items:
+  - "{{ idr_instance_network_networks }}"


### PR DESCRIPTION
If you need to add a new network to an existing openstack instance you can use this role. This role only handles the openstack side of things, you will also need to configure your instance to use the additional network. If you only require very basic configuration use the role from https://github.com/openmicroscopy/infrastructure/pull/200

See the example in the README of this role.