### PR TITLE
Cap requests version below 2.12.2

### DIFF
--- a/ansible/roles/devspace/tasks/devspace-install.yml
+++ b/ansible/roles/devspace/tasks/devspace-install.yml
@@ -49,10 +49,6 @@
     - passlib
     - pyyaml
     - docker-compose
-    # Temporary fix - cap requests to version below 2.12.2
-    # See https://github.com/kennethreitz/requests/issues/3734 and
-    # https://github.com/docker/docker-py/issues/1321
-    - requests<2.12.2
 
 # TEMP: Error: docker-py version is 1.10.2. Minimum version required is 1.7.0.
 # see https://github.com/ansible/ansible/issues/17495

--- a/ansible/roles/devspace/tasks/devspace-install.yml
+++ b/ansible/roles/devspace/tasks/devspace-install.yml
@@ -49,6 +49,10 @@
     - passlib
     - pyyaml
     - docker-compose
+    # Temporary fix - cap requests to version below 2.12.2
+    # See https://github.com/kennethreitz/requests/issues/3734 and
+    # https://github.com/docker/docker-py/issues/1321
+    - requests<2.12.2
 
 # TEMP: Error: docker-py version is 1.10.2. Minimum version required is 1.7.0.
 # see https://github.com/ansible/ansible/issues/17495
@@ -59,6 +63,8 @@
     state: latest
   with_items:
     - docker-py==1.9.0
+    # Same as above
+    - requests<2.12.2
 
 - name: clone devspace
   become: yes


### PR DESCRIPTION
Last release seems to have broken docker-py /cc @joshmoore @aleksandra-tarkowska 

See https://github.com/ansible/ansible-modules-core/issues/5775 and
https://github.com/kennethreitz/requests/issues/3734 for the relevant issues