### PR TITLE
nginx role can optionally setup mainline instead of stable repo (IDR-0.3.1)

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -59,6 +59,7 @@ Vagrant.configure(2) do |config|
 
   [
     "nginx",
+    "nginx-mainline",
     "omero-server",
   ].each do |server|
     config.vm.define "#{server}" do |node|

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -58,6 +58,7 @@ Vagrant.configure(2) do |config|
   end
 
   [
+    "nginx",
     "omero-server",
   ].each do |server|
     config.vm.define "#{server}" do |node|

--- a/ansible/roles/nginx/README.md
+++ b/ansible/roles/nginx/README.md
@@ -15,6 +15,7 @@ Log rotation:
 
 - `nginx_logrotate_interval`: Rotate log files at this interval, default `daily`
 - `nginx_logrotate_backlog_size`: Number of backlog files to keep, default `366`
+- `nginx_stable_repo`: If `False` use the mainline instead of stable repo, default `True`
 
 
 Author Information

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -6,3 +6,6 @@ nginx_logrotate_interval: daily
 
 # Number of backlog files to keep
 nginx_logrotate_backlog_size: 366
+
+# Use stable or mainline?
+nginx_stable_repo: True

--- a/ansible/roles/nginx/files/nginx-mainline.repo
+++ b/ansible/roles/nginx/files/nginx-mainline.repo
@@ -1,0 +1,5 @@
+[nginx]
+name=nginx repo
+baseurl=http://nginx.org/packages/mainline/centos/$releasever/$basearch/
+gpgcheck=0
+enabled=1

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -2,11 +2,19 @@
 # tasks file for roles/nginx
 
 
-- name: system packages | setup upstream nginx repo
+- name: system packages | setup upstream nginx stable repo
   become: yes
   yum:
     name: https://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm
     state: present
+  when: nginx_stable_repo
+
+- name: system packages | setup upstream nginx mainline repo
+  become: yes
+  copy:
+    src: nginx-mainline.repo
+    dest: /etc/yum.repos.d/nginx-mainline.repo
+  when: not nginx_stable_repo
 
 - name: system packages | install nginx
   become: yes

--- a/ansible/tests/nginx-mainline.yml
+++ b/ansible/tests/nginx-mainline.yml
@@ -1,0 +1,15 @@
+- hosts: nginx-mainline
+  roles:
+  - role: nginx
+    nginx_stable_repo: no
+
+  tasks:
+  - command: /usr/sbin/nginx -v
+    register: ng_version
+    changed_when: False
+
+  # This will need to be updated when the major version is incremented
+  - assert:
+      that: >
+        "{{ ng_version.stderr | regex_replace('.+/(\d+\.\d+)\.\d+$', '\1') }}"
+        == "1.11"

--- a/ansible/tests/nginx.yml
+++ b/ansible/tests/nginx.yml
@@ -1,0 +1,14 @@
+- hosts: nginx
+  roles:
+  - role: nginx
+
+  tasks:
+  - command: /usr/sbin/nginx -v
+    register: ng_version
+    changed_when: False
+
+  # This will need to be updated when the major version is incremented
+  - assert:
+      that: >
+        "{{ ng_version.stderr | regex_replace('.+/(\d+\.\d+)\.\d+$', '\1') }}"
+        == "1.10"


### PR DESCRIPTION
Adds a variable to setup Nginx mainline (currently 1.11) instead of the default stable (1.10). This does not support switching between these two repositories on an existing Nginx server.

The new IDR caching config requires support for complex maps which requires Nginx 1.11.