### PR TITLE
Add optional nginx_proxy_cache_key_map for modifying cache key (IDR-0.3.1)

### DIFF
--- a/ansible/roles/nginx-proxy/README.md
+++ b/ansible/roles/nginx-proxy/README.md
@@ -100,6 +100,10 @@ Caching:
 - `nginx_proxy_cache_ignore_headers`: Headers to be ignored, e.g. `'"Set-Cookie" "Vary" "Expires"'`
 - `nginx_proxy_cache_hide_headers`: Headers to be hidden from clients in cached responses, must be a list e.g. `[Set-Cookie]`
 - `nginx_proxy_cache_key`: Override the default Nginx cache key, for example `"$host$request_uri"` to ignore session cookies
+- `nginx_proxy_cache_key_map`: Optionally map `nginx_proxy_cache_key` to the desired cache key, for instance if you want to ignore part of the url. This should be a list of dictionaries with fields:
+  - `match`: Match in nginx_proxy_cache_key
+  - `key`: The cache key
+`nginx_proxy_cache_key` is always included as the default.
 - `nginx_proxy_cache_use_stale`: Situations in which stale cache results should be returned, see `defaults/main.yml` for default
 - `nginx_proxy_cache_lock_time`: Prevent multiple backend requests to the same object (subsequent requests will wait for the first to either return or time-out), default 1 minute
 - `nginx_proxy_cachebuster_port`: An alternative port which can be used to force a cache refresh, disabled by default. You should ensure this is firewalled. If SELinux is enabled and the port is not one that nginx can bind by default (typically 80, 81, 443, 488, 8008, 8009, 8443, 9000 are allowed by default) you must update your policy yourself.

--- a/ansible/roles/nginx-proxy/defaults/main.yml
+++ b/ansible/roles/nginx-proxy/defaults/main.yml
@@ -114,6 +114,9 @@ nginx_proxy_cache_hide_headers: []
 # Override the default Nginx cache key
 nginx_proxy_cache_key:
 
+# Manipulate the cache key
+nginx_proxy_cache_key_map: {}
+
 # Use stale cache if these situations are encountered
 nginx_proxy_cache_use_stale: "error timeout invalid_header updating http_500 http_502 http_503 http_504"
 

--- a/ansible/roles/nginx-proxy/defaults/main.yml
+++ b/ansible/roles/nginx-proxy/defaults/main.yml
@@ -115,7 +115,7 @@ nginx_proxy_cache_hide_headers: []
 nginx_proxy_cache_key:
 
 # Manipulate the cache key
-nginx_proxy_cache_key_map: {}
+nginx_proxy_cache_key_map: []
 
 # Use stale cache if these situations are encountered
 nginx_proxy_cache_use_stale: "error timeout invalid_header updating http_500 http_502 http_503 http_504"

--- a/ansible/roles/nginx-proxy/templates/nginx-confd-proxy-cache.j2
+++ b/ansible/roles/nginx-proxy/templates/nginx-confd-proxy-cache.j2
@@ -43,3 +43,13 @@ map $request_uri $cache_zone_name
 {%   endfor %}
 {% endfor %}
 }
+
+{% if nginx_proxy_cache_key %}
+map {{ nginx_proxy_cache_key }} $cache_key
+{
+    default {{ nginx_proxy_cache_key }};
+{%   for item in nginx_proxy_cache_key_map %}
+    {{ item.match }} {{ item.key }};
+{%   endfor %}
+}
+{% endif %}

--- a/ansible/roles/nginx-proxy/templates/nginx-confd-proxy.j2
+++ b/ansible/roles/nginx-proxy/templates/nginx-confd-proxy.j2
@@ -104,7 +104,7 @@ server {
 {%   if item.cache_validity | default(False) %}
         proxy_cache            $cache_zone_name;
 {%     if nginx_proxy_cache_key %}
-        proxy_cache_key        "{{ nginx_proxy_cache_key }}";
+        proxy_cache_key        $cache_key;
 {%     endif %}
         proxy_cache_valid      200 {{ item.cache_validity }};
         proxy_cache_methods    GET HEAD; # Only GET and HEAD methods apply
@@ -119,7 +119,7 @@ server {
         add_header             X-Proxy-Cache-Skip $skip_cache;
         add_header             X-Proxy-Cache-Zone $cache_zone_name;
 {%       if nginx_proxy_cache_key %}
-        add_header             X-Proxy-Cache-Key "{{ nginx_proxy_cache_key }}";
+        add_header             X-Proxy-Cache-Key $cache_key;
 {%       endif %}
 {%     endif %}
 


### PR DESCRIPTION
Adds a parameter to optionally modify the cache-key based on a regex-match.

This is required for the new IDR caching config.

Running this on an existing server will result in a configuration change, but there should be no functional difference (it'll create a map with a single default value which is equivalent to using that value directly).