### PR TITLE
copy snoopy keys

### DIFF
--- a/ansible/roles/jenkinsslave/tasks/main.yml
+++ b/ansible/roles/jenkinsslave/tasks/main.yml
@@ -34,6 +34,7 @@
     owner={{ jenkinsuser }}
     group={{ jenkinsuser }}
     mode=0700
+    remote_src=True
   with_items:
     - { srcfile: "config", dest: ".ssh/config" }
     - { srcfile: "snoopycrimecop_github", dest: ".ssh/snoopycrimecop_github" }


### PR DESCRIPTION
copy snoopy keys:
Add remote_src parameter
Without the new parameter, it always fails with this error
``
TASK [jenkinsslave : copy snoopy keys] *****************************************
fatal: [cowfish.openmicroscopy.org]: FAILED! => {"failed": true, "msg": "the file_name '/home/hudson/.ssh/config' does not exist, or is not readable"}
``
ansible version used: 2.1.1.0

To test, run the playbook `` ci-deployment.yml`` against cowfish with ``--ask-become-pass -C`` options
