### PR TITLE
Add role for managing /etc/hosts in openstack instances (IDR-0.3.1)

### DIFF
--- a/ansible/roles-dev/hosts-populate/README.md
+++ b/ansible/roles-dev/hosts-populate/README.md
@@ -1,0 +1,21 @@
+Hosts Populate
+==============
+
+Populates `/etc/hosts` with static addresses for a list of hostgroups.
+
+
+Role Variables
+--------------
+
+Optional variables:
+- `hosts_populate_iface`: Lookup the host IP using this network interface, default `eth0`
+- `hosts_populate_openstack_groups`: List of openstack groups, hosts from these groups will be included in `/etc/hosts`.
+  In practice this will probably work with non-openstack groups too.
+
+Warning: This role requires full control of `/etc/hosts`.
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles-dev/hosts-populate/tasks/main.yml
+++ b/ansible/roles-dev/hosts-populate/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for roles/hosts-populate
+
+- name: hosts | update /etc/hosts
+  become: yes
+  template:
+    dest: /etc/hosts
+    backup: yes
+    src: etc-hosts.j2

--- a/ansible/roles-dev/hosts-populate/templates/etc-hosts.j2
+++ b/ansible/roles-dev/hosts-populate/templates/etc-hosts.j2
@@ -1,0 +1,11 @@
+# Managed by Ansible
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+{% for group in (hosts_populate_openstack_groups | default([])) %}
+# Group {{ group }}
+{%   for host in (groups[group] | default([])) %}
+{{ hostvars[host]['ansible_' + (hosts_populate_iface | default('eth0'))].ipv4.address }} {{ hostvars[host].ansible_hostname }}
+{%   endfor %}
+
+{% endfor %}


### PR DESCRIPTION
This role takes a list of openstack ansible groups, and populates `/etc/hosts` on a given server with the IPs and hostnames of all servers in those groups. It may also work for normal (non-openstack) groups too.

See #215 for an example