### PR TITLE
Setup /etc/hosts on bastion hosts (IDR-0.3.1)

### DIFF
--- a/ansible/idr-playbooks/idr-03-postinstall.yml
+++ b/ansible/idr-playbooks/idr-03-postinstall.yml
@@ -1,3 +1,5 @@
 # IDR post-installation playbooks
 
 - include: idr-reset-users-groups.yml
+
+- include: idr-bastion.yml

--- a/ansible/idr-playbooks/idr-bastion.yml
+++ b/ansible/idr-playbooks/idr-bastion.yml
@@ -1,0 +1,17 @@
+# Tasks specific to bastion hosts
+
+- hosts: >
+    {{ idr_environment | default('idr') }}-hosts
+    {{ idr_environment | default('idr') }}-a-hosts
+# Load hostvars
+
+# Setup /etc/hosts on bastion hosts
+- hosts: >
+    {{ idr_environment | default('idr') }}-bastion-hosts
+    {{ idr_environment | default('idr') }}-a-bastion-hosts
+
+  roles:
+  - role: hosts-populate
+    hosts_populate_openstack_groups:
+    - "{{ idr_environment | default('idr') }}-hosts"
+    - "{{ idr_environment | default('idr') }}-a-hosts"


### PR DESCRIPTION
This populates `/etc/hosts` on the IDR bastion servers with a list of hosts in the same idr-environment. This means you can `ssh` into the bastion server and connect to other hosts by hostname instead of having to lookup the IP.

e.g.
```
ssh -A `floating-ip-of-demoNN-bastion-host
ssh demoNN-omero
```

--depends-on #214