### PR TITLE
Install parallel on IDR OMERO servers (IDR-0.3.1)

### DIFF
--- a/ansible/idr-playbooks/idr-omero.yml
+++ b/ansible/idr-playbooks/idr-omero.yml
@@ -75,6 +75,7 @@
     tags: "python-pydata"
   - role: omero-web-apps
     tags: "omero-web-apps"
+  - role: analysis-tools
 
   vars:
     omero_dbhost: "{{ omero_db_host_ansible }}"

--- a/ansible/roles/analysis-tools/tasks/main.yml
+++ b/ansible/roles/analysis-tools/tasks/main.yml
@@ -7,4 +7,4 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - moreutils-parallel
+    - parallel


### PR DESCRIPTION
I've no idea why `analysis-tools` was installing `moreutils-parallel`. Changed to install `parallel` and this roles has been added to `idr-playbooks/idr-omero.yml`.