### PR TITLE
Install jinja2 PyYAML in omero-python-deps (IDR-0.3.1)

### DIFF
--- a/ansible/roles/omero-python-deps/tasks/main.yml
+++ b/ansible/roles/omero-python-deps/tasks/main.yml
@@ -15,10 +15,12 @@
   with_items:
     - Cython
     - numpy
+    - python-jinja2
     - python-matplotlib
     - python-numexpr
     - python-tables
     - python-pip
+    - PyYAML
     - scipy
   when: "{{ omero_python_deps_recommended }}"
 


### PR DESCRIPTION
The OMERO.server `metadata` plugin requires the YAML and Jinja2 python modules.