### PR TITLE
Refactor java role (IDR-0.3.1)

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -58,6 +58,7 @@ Vagrant.configure(2) do |config|
   end
 
   [
+    "java",
     "nginx",
     "nginx-mainline",
     "omero-server",

--- a/ansible/roles/java/README.md
+++ b/ansible/roles/java/README.md
@@ -3,13 +3,14 @@ Java
 
 Install Java JREs and optionally JDKs.
 
+
 Role Variables
 --------------
 
 Optional variables:
+- `java_jre_versions`: A list of JRE versions to install, default `[1.8.0]`
+- `java_jdk_install`: If `True` install JDKs corresponding to the JRE versions, default `False`
 
-- `javajreversions`: A list of JRE versions to install, default `[1.8.0]`
-- `javajdkversions`: A list of JDK versions to install, default None
 
 Author Information
 ------------------

--- a/ansible/roles/java/defaults/main.yml
+++ b/ansible/roles/java/defaults/main.yml
@@ -2,8 +2,8 @@
 # defaults file for roles/java
 
 # List of JRE versions to install
-javajreversions:
+java_jre_versions:
   - 1.8.0
 
-# List of JDK versions to install
-javajdkversions: []
+# Install JDKs corresponding to JREs?
+java_jdk_install: False

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -6,11 +6,12 @@
   yum:
     name: "java-{{ item }}-openjdk"
     state: present
-  with_items: "{{ javajreversions | default([]) }}"
+  with_items: "{{ java_jre_versions }}"
 
 - name: system packages | install java jdk
   become: yes
   yum:
     name: "java-{{ item }}-openjdk-devel"
     state: present
-  with_items: "{{ javajdkversions | default([]) }}"
+  when: "{{ java_jdk_install }}"
+  with_items: "{{ java_jre_versions }}"

--- a/ansible/tests/java.yml
+++ b/ansible/tests/java.yml
@@ -1,0 +1,36 @@
+# JRE only
+- hosts: java
+  roles:
+  - role: java
+
+  tasks:
+  - stat:
+      path: /usr/bin/java
+    register: st1_java
+
+  - stat:
+      path: /usr/bin/javac
+    register: st1_javac
+
+  # WARNING: This will only pass on the first run, since the next playbook
+  # invalidates this assert
+  - assert:
+      that:
+      - "st1_java.stat.exists"
+      - "not st1_javac.stat.exists"
+
+
+# JRE and JDK
+- hosts: java
+  roles:
+  - role: java
+    java_jdk_install: True
+
+  tasks:
+  - stat:
+      path: /usr/bin/javac
+    register: st2_javac
+
+  - assert:
+      that:
+      - "st2_javac.stat.exists"


### PR DESCRIPTION
- Use `_` in variable names
- Control JDK installation with a boolean instead of requiring a list of versions, since it probably makes sense for this to be the same as the JRE versions

This is a breaking change, but nothing is currently using these variables.