### PR TITLE
Install JDK on idr OMERO for jstack (IDR-0.3.1)

### DIFF
--- a/ansible/idr-playbooks/group_vars/omero-hosts.yml
+++ b/ansible/idr-playbooks/group_vars/omero-hosts.yml
@@ -75,3 +75,10 @@ omero_web_app_add_top_links:
   attrs:
     target: new
     title: Open OMERO user guide in a new tab
+
+
+######################################################################
+# Other omero configuration
+
+# Install JDK to provide jstack
+java_jdk_install: True


### PR DESCRIPTION
Update the IDR playbooks to install `jstack` on the OMERO servers. This requires installing the JDK.

--depends-on https://github.com/openmicroscopy/infrastructure/pull/219