### PR TITLE
Work around issues in Ansible 2.2

### DIFF
--- a/ansible/roles/ice/tasks/main.yml
+++ b/ansible/roles/ice/tasks/main.yml
@@ -32,10 +32,18 @@
   with_items: "{{ ice_pip_dependencies }}"
   when: ice_pip_dependencies
 
-- name: zeroc ice | pip install packages
+- name: zeroc ice | pip install packages (ansible < 2.2)
   become: yes
   pip:
     name: "{{ item }}"
     state: present
   with_items: "{{ ice_pip_packages }}"
-  when: ice_pip_packages
+  when: "ice_pip_packages and {{ ansible_version.full | version_compare('2.2', '<') }}"
+
+# https://github.com/ansible/ansible/issues/19321
+- name: zeroc ice | pip install packages (ansible >= 2.2)
+  become: yes
+  pip:
+    name: "{{ ice_pip_packages }}"
+    state: present
+  when: "ice_pip_packages and {{ ansible_version.full | version_compare('2.2', '>=') }}"

--- a/ansible/roles/omero-web-runtime/tasks/main.yml
+++ b/ansible/roles/omero-web-runtime/tasks/main.yml
@@ -8,14 +8,25 @@
     state: present
   when: omero_web_runtime_redis
 
-- name: omero web | pip install packages
+- name: omero web | pip install packages (ansible < 2.2)
   become: yes
   pip:
     name: "{{ item }}"
     state: present
+  when: "{{ ansible_version.full | version_compare('2.2', '<') }}"
   with_items:
     - "django>=1.8,<1.9"
     - "gunicorn>=19.3"
+
+# https://github.com/ansible/ansible/issues/19321
+- name: omero web | pip install packages (ansible >= 2.2)
+  become: yes
+  pip:
+    name:
+    - "django>=1.8,<1.9"
+    - "gunicorn>=19.3"
+    state: present
+  when: "{{ ansible_version.full | version_compare('2.2', '>=') }}"
 
 - name: omero-web | install django redis requirements
   become: yes


### PR DESCRIPTION
This works around a bug(?) in Ansible 2.2 involving complex pip requirements: https://github.com/ansible/ansible/issues/19321

This should allow most of the dependencies of the `omero-server` role to be installed, however there's another Ansible bug involving virtualenvs which means `omego` gets installed into the wrong place.