### PR TITLE
Initialise all NICs when multiple cloud networks are present (IDR-0.3.1)

### DIFF
--- a/ansible/idr-playbooks/idr-00-preinstall.yml
+++ b/ansible/idr-playbooks/idr-00-preinstall.yml
@@ -1,6 +1,8 @@
 # Runs all storage related playbooks for setting up the IDR infrastructure
 # This will be specific to your Openstack and local environment
 
+- include: idr-networks.yml
+
 - include: idr-upgrade-dist.yml
 - include: os-idr-volumes.yml
 - include: idr-dundee-nfs.yml

--- a/ansible/idr-playbooks/idr-networks.yml
+++ b/ansible/idr-playbooks/idr-networks.yml
@@ -3,13 +3,7 @@
 # This is needed because the proxy server provides ssh-proxy access to
 # multiple networks, but only the firgst NIC is automatically configured.
 
-- hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
+- hosts: "{{ idr_environment | default('idr') }}-bastion-hosts"
 
   roles:
-  - role: network
-    network_basic_ifaces:
-    - device: eth1
-      bootproto: dhcp
-      mtu:
-      type: Ethernet
-      defroute: "no"
+  - role: network-cloud-interfaces

--- a/ansible/idr-playbooks/idr-networks.yml
+++ b/ansible/idr-playbooks/idr-networks.yml
@@ -1,9 +1,16 @@
-# Setup the IDR gateway networking
+# Setup the IDR additional network interfaces
 #
-# This is needed because the proxy server provides ssh-proxy access to
-# multiple networks, but only the firgst NIC is automatically configured.
+# This is needed because only the first NIC is automatically configured
 
+# Update the bastion servers first since they provides ssh-proxy access to
+# other servers
 - hosts: "{{ idr_environment | default('idr') }}-bastion-hosts"
+  roles:
+  - role: network-cloud-interfaces
 
+# All other hosts (e.g. those requiring NFS access on a separate network)
+- hosts: >
+    {{ idr_environment | default('idr') }}-hosts
+    {{ idr_environment | default('idr') }}-a-hosts
   roles:
   - role: network-cloud-interfaces

--- a/ansible/idr-playbooks/idr-networks.yml
+++ b/ansible/idr-playbooks/idr-networks.yml
@@ -1,0 +1,15 @@
+# Setup the IDR gateway networking
+#
+# This is needed because the proxy server provides ssh-proxy access to
+# multiple networks, but only the firgst NIC is automatically configured.
+
+- hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
+
+  roles:
+  - role: network
+    network_basic_ifaces:
+    - device: eth1
+      bootproto: dhcp
+      mtu:
+      type: Ethernet
+      defroute: "no"


### PR DESCRIPTION
Attempt to initialise all NICs before any other configuration is done.

This is important when using a bastion server on multiple networks, since by default only the first NIC is initialised, which would prevent internal hosts from being accessed via the uninitialised NIC.