### PR TITLE
Miscellaneous small IDR fixes (IDR-0.3.1)

### DIFF
--- a/ansible/idr-playbooks/idr-ebi-nfs.yml
+++ b/ansible/idr-playbooks/idr-ebi-nfs.yml
@@ -35,7 +35,8 @@
     mount:
       fstype: nfs
       name: "{{ nfs_mountpoint }}"
-      opts: rsize=8192,wsize=8192,timeo=14,intr,nolock
+      # Removed rsize=8192,wsize=8192, this should be auto-negotiated
+      opts: timeo=14,intr,nolock
       src: 10.35.106.250:/ivol_bioimage_sm
       state: mounted
 

--- a/ansible/idr-playbooks/idr-proxy.yml
+++ b/ansible/idr-playbooks/idr-proxy.yml
@@ -35,7 +35,7 @@
             idr_environment | default('idr') + '-a-dockermanager-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}:8000
-    when: "{{ groups[idr_environment | default('idr') + '-a-dockermanager-hosts'] | length > 0 }}"
+    when: "{{ groups[idr_environment | default('idr') + '-a-dockermanager-hosts'] is defined }}"
 
   roles:
   # Default to a self-signed certificate, set `idr_nginx_ssl_production: True`

--- a/ansible/idr-playbooks/idr-upgrade-dist.yml
+++ b/ansible/idr-playbooks/idr-upgrade-dist.yml
@@ -4,7 +4,6 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-hosts
     {{ idr_environment | default('idr') }}-a-hosts
-    management-hosts
   roles:
   - role: upgrade-distpackages
   # Ideally we should auto-reboot, but if the SSH proxy host is rebooted

--- a/ansible/scripts/os-idr-snapshot.sh
+++ b/ansible/scripts/os-idr-snapshot.sh
@@ -14,7 +14,13 @@ vm_prefix="$1"
 today=$(date +%Y%m%d)
 errors=0
 
-for vm in database omero gateway; do
+for vm in \
+        database \
+        omero \
+        proxy \
+        a-dockermanager \
+        management \
+        ; do
     server="$vm_prefix-$vm"
     echo "Snapshotting server $server"
     openstack server image create --name "$server-$today" "$server" -f yaml
@@ -22,7 +28,12 @@ for vm in database omero gateway; do
     echo
 done
 
-for vol in database-db omero-data gateway-nginxcache; do
+for vol in \
+        database-db \
+        omero-data \
+        proxy-nginxcache \
+        a-dockermanager-jupyter \
+        ; do
     volume="$vm_prefix-$vol"
     echo "Snapshotting volume $volume"
     openstack snapshot create --force --name "$volume-$today" "$volume" -f yaml


### PR DESCRIPTION
- `management-hosts` shouldn't be referenced directly, it's already part of an idr-environment group
- `Changed a variable test so that the proxy can be automatically configured in the absence of an analysis platform`
- `Changed the EBI NFS mount options to allow auto-negotiation`
- Updated the `os-idr-snapshot.sh` script.