### PR TITLE
Separate role to reboot server (IDR-0.3.1)

### DIFF
--- a/ansible/idr-playbooks/idr-reboot-if-kernel.yml
+++ b/ansible/idr-playbooks/idr-reboot-if-kernel.yml
@@ -1,0 +1,27 @@
+---
+# Auto-reboot if the kernel was upgraded.
+
+# If the SSH proxy host is rebooted this breaks connections to all the
+# backend servers and ansible may hang, so reboot bastion hosts separately.
+
+
+# Reboot non-bastion hosts, don't wait because checking that SSH is open
+# via a proxy-host is difficult
+- hosts: >
+    {{ idr_environment | default('idr') }}-hosts
+    {{ idr_environment | default('idr') }}-a-hosts
+    !bastion-hosts
+  roles:
+  - role: reboot-server
+    reboot_server_timeout: 0
+
+
+# Reboot bastion hosts, don't wait because with the default dynamic inventory
+# it proxies itself instead of using the external IP
+- hosts: >
+    {{ idr_environment | default('idr') }}-hosts
+    {{ idr_environment | default('idr') }}-a-hosts
+    &bastion-hosts
+  roles:
+  - role: reboot-server
+    reboot_server_timeout: 0

--- a/ansible/roles-dev/reboot-server/README.md
+++ b/ansible/roles-dev/reboot-server/README.md
@@ -1,0 +1,26 @@
+Reboot Server
+=============
+
+Reboot a server, optionally wait for it to return
+
+If `reboot_server_timeout > 0` then wait for server to start.
+This may fail if the server takes longer than `reboot_server_wait` seconds to shutdown all services, you can avoid this by increasing `reboot_server_wait`.
+The post-reboot check requires direct access to the server from `localhost`.
+If the server is behind a proxy you can run the check from a different host using `reboot_server_delegate`.
+
+
+Role Variables
+--------------
+
+Optional variables:
+- `reboot_server_always`: If `True` unconditionally reboot the server, otherwise only reboot if the kernel has changed, default `False`
+- `reboot_server_delegate`: Run the reboot check from this node, default `localhost`.
+- `reboot_server_shutdown_delay`: Wait for this time (seconds) before shutting down the server, default `5`
+- `reboot_server_wait`: Wait for this time (seconds) before checking whether the server has restarted, default `30`
+- `reboot_server_timeout`: Maximum time (seconds) to wait for a reboot, default `300`
+
+
+Author Information
+------------------
+
+ome-devel@lists.openmicroscopy.org.uk

--- a/ansible/roles-dev/reboot-server/defaults/main.yml
+++ b/ansible/roles-dev/reboot-server/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# defaults file for roles/reboot-server
+
+# If True unconditionally reboot the server, otherwise only reboot if the
+# kernel has changed
+reboot_server_always: False
+
+# Run the reboot check from this node
+reboot_server_delegate: localhost
+
+# Wait for this time (seconds) before shutting down the server
+reboot_server_shutdown_delay: 5
+
+# Wait for this time (seconds) before checking whether the server has restarted
+reboot_server_wait: 30
+
+# Maximum time (seconds) to wait for a reboot
+reboot_server_timeout: 300

--- a/ansible/roles-dev/reboot-server/tasks/main.yml
+++ b/ansible/roles-dev/reboot-server/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+# tasks file for roles/reboot-server
+
+- include: reboot-if-kernel-upgraded.yml
+
+- include: reboot-server.yml
+  when: "{{ reboot_server_needed | default(reboot_server_always) }}"

--- a/ansible/roles-dev/reboot-server/tasks/reboot-if-kernel-upgraded.yml
+++ b/ansible/roles-dev/reboot-server/tasks/reboot-if-kernel-upgraded.yml
@@ -1,0 +1,23 @@
+---
+# Reboot a server if the running kernel is older than the latest installed
+
+- name: reboot | current running kernel
+  command: uname -r
+  register: running_kernel_version
+  always_run: True
+  changed_when: False
+
+# http://serverfault.com/a/601432
+- name: reboot | latest installed kernel
+  shell: rpm -q kernel --qf '%{BUILDTIME} %{VERSION}-%{RELEASE}.%{ARCH}\n' | tail -n 1 | cut -f 2 -d ' '
+  register: latest_kernel_version
+  always_run: True
+  changed_when: False
+
+- name: reboot | check if reboot needed
+  set_fact:
+    reboot_server_needed: "{{ running_kernel_version.stdout != latest_kernel_version.stdout }}"
+
+- debug:
+    msg: "Reboot needed (kernel): Current:{{ running_kernel_version.stdout }} Latest:{{ latest_kernel_version.stdout }}"
+  when: "{{ reboot_server_needed }}"

--- a/ansible/roles-dev/reboot-server/tasks/reboot-server.yml
+++ b/ansible/roles-dev/reboot-server/tasks/reboot-server.yml
@@ -1,0 +1,19 @@
+---
+# https://support.ansible.com/hc/en-us/articles/201958037-Reboot-a-server-and-wait-for-it-to-come-back
+- name: reboot | asynchronous reboot
+  become: yes
+  shell: "sleep {{ reboot_server_shutdown_delay }} && shutdown -r now 'Rebooting (Ansible)'"
+  async: 1
+  poll: 0
+  ignore_errors: False
+  changed_when: True
+
+- name: reboot | wait for server
+  delegate_to: "{{ reboot_server_delegate }}"
+  wait_for:
+    delay: "{{ reboot_server_wait }}"
+    host: "{{ ansible_host | default(inventory_hostname) }}"
+    port: "{{ ansible_port | default(22) }}"
+    state: "started"
+    timeout: "{{ reboot_server_timeout }}"
+  when: "{{ reboot_server_timeout > 0 }}"


### PR DESCRIPTION
A development role for rebooting servers either if the kernel has been changed, or unconditionally, depending on the configuration options.

Also adds an IDR playbook for rebooting servers after a kernel upgrade.

Once this is stable it should replace the reboot tasks in `roles/upgrade-distpackages`.

This role/playbook are needed because rebooting servers behind a proxy host gets complicated if the proxy host also requires a reboot, since it'll lead to the unexpected interruption of a SSH connections to internal servers. This means it must be carefully ordered.