### PR TITLE
Capture Ansible requirements in requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: pip
 
 install:
-  - pip install ansible
+  - pip install -r requirements.txt
 
 script:
     - |

--- a/README.md
+++ b/README.md
@@ -17,14 +17,11 @@ for full installation instructions.
 
 ### Installation
 
-- Create a virtual environment and install Ansible:
+- Create a virtual environment and install the Ansible requirements (including
+  `shade` for using with OpenStack):
 
         virtualenv ~/venvs/ansible
-        ~/venvs/ansible/bin/pip install ansible
-
-- If using Ansible with OpenStack, you might want to install `shade`:
-
-        ~/venvs/ansible/bin/pip install shade
+        ~/venvs/ansible/bin/pip install -r requirements.txt
 
 - Clone this repository:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ansible
+shade==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible
-shade==1.11.1
+ansible==2.1.3.0
+shade==1.13.2


### PR DESCRIPTION
While trying to initiate a VM on an OpenStack instance, I encountered https://groups.google.com/forum/#!msg/ansible-project/3pj7jknSqd8/cr4Zt6L2BQAJ.

Rather than hardcoding the version in various places in the documentation, this PR migrates all the Python dependencies into a top-level `requirements.txt` as we do for any Python app. Dependencies can be pinned and upgraded via PR.

Travis is also updated to consume the requirements file.