### PR TITLE
Disable all routes apart from eth0 in network-cloud-interfaces (IDR-0.3.2)

### DIFF
--- a/ansible/roles/network-cloud-interfaces/files/dhcp-dhclient-enter-hooks
+++ b/ansible/roles/network-cloud-interfaces/files/dhcp-dhclient-enter-hooks
@@ -1,0 +1,11 @@
+# Disable default route for all interfaces apart from eth0
+case $reason in
+  BOUND|RENEW|REBIND|REBOOT)
+    if [ "$interface" != eth0 ]; then
+      logger -t cloud-dhclient "Unsetting $interface new_routers=$new_routers"
+      unset new_routers
+      logger -t cloud-dhclient "Unsetting $interface new_classless_static_routes=$new_classless_static_routes"
+      unset new_classless_static_routes
+    fi
+    ;;
+esac

--- a/ansible/roles/network-cloud-interfaces/tasks/main.yml
+++ b/ansible/roles/network-cloud-interfaces/tasks/main.yml
@@ -25,6 +25,13 @@
   with_items: "{{ network_cloud_interfaces | default(ansible_interfaces) }}"
   register: network_cloud_modified
 
+- name: network cloud | disable default routes
+  become: yes
+  copy:
+    dest: /etc/dhcp/dhclient-enter-hooks
+    src: dhcp-dhclient-enter-hooks
+    mode: 0755
+
 - name: network cloud | start new nics
   become: yes
   command: /usr/sbin/ifup {{ item.item }}


### PR DESCRIPTION
If a CentOS 7 cloud instance has multiple openstack DHCP interfaces the default gateway/route may end up on a random interface. This causes problems with external access if only one of the interfaces has a floating IP. This PR adds a client-side DHCP hook to disable all routes other than for `eth0`.

This is a dumb "do-the-right-thing" role for setting up cloud networks so it's not configurable. If you need something more complicated use the `network` role in combination with additional tasks for handling config.