### PR TITLE
Demo32 cleanups (IDR-0.3.2)

### DIFF
--- a/ansible/idr-playbooks/idr-00-preinstall.yml
+++ b/ansible/idr-playbooks/idr-00-preinstall.yml
@@ -6,7 +6,3 @@
 - include: idr-dundee-nfs.yml
 - include: idr-ebi-nfs.yml
 
-# Uncomment this to upgrade all packages in the base image. This shouldn't be
-# necessary if you are using a recent base image unless you need to install a
-# critical fix.
-#- include: idr-upgrade-dist.yml

--- a/ansible/idr-playbooks/idr-ebi-nfs.yml
+++ b/ansible/idr-playbooks/idr-ebi-nfs.yml
@@ -3,16 +3,6 @@
     {{ idr_environment | default('idr') }}-ebi-nfs
     {{ idr_environment | default('idr') }}-a-ebi-nfs
 
-  roles:
-
-  # The NFS network
-  - role: network
-    network_basic_ifaces:
-    - device: eth1
-      bootproto: dhcp
-      mtu:
-      type: Ethernet
-
   tasks:
 
   - name: Create NFS group


### PR DESCRIPTION
- The post-kernel-upgrade reboot is handled in a separate playbook (not run by default)
- Multi-interface network config is handled in another playbook