### PR TITLE
Disable nginx port_in_redirect (IDR-0.3.1)

### DIFF
--- a/ansible/roles/nginx-proxy/templates/nginx-confd-proxy.j2
+++ b/ansible/roles/nginx-proxy/templates/nginx-confd-proxy.j2
@@ -63,6 +63,8 @@ server {
     proxy_set_header {{ nginx_proxy_forward_scheme_header }} $scheme;
 {% endif %}
 
+    port_in_redirect off;
+
 {% for item in nginx_proxy_redirect_map_locations %}
     location {{ item.location }} {
         return {{ item.code | default('302') }} $redirect_uri;


### PR DESCRIPTION
This is an attempt to make Nginx redirects relative to `host:port` instead of the default which is to use the `host` only. It didn't have the desired effect with OMERO.web, but it's been deployed anyway.

- http://nginx.org/en/docs/http/ngx_http_core_module.html#port_in_redirect
- http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name_in_redirect