### PR TITLE
Revert VM used for devspace to m2.large

### DIFF
--- a/ansible/os-devspace.yml
+++ b/ansible/os-devspace.yml
@@ -15,7 +15,7 @@
   vars:
 
     vm_image: "CentOS 7"
-    vm_flavour: m1.large
+    vm_flavour: m2.large
     vm_size: 50
     vm_groups: "ansible-managed,os-image-centos,docker-hosts,devspace"
 


### PR DESCRIPTION
The previous modification to use m1.large was done in the context of testing the new installation as the m2.large VM was not available. In order to complete the OMERO jobs, a VM with larger RAM capacity is necessary.