### PR TITLE
Add jq install to openstack post

### DIFF
--- a/ansible/idr-openstack-post.yml
+++ b/ansible/idr-openstack-post.yml
@@ -11,3 +11,10 @@
 
   vars:
     network_ifaces: "{{ post_network_ifaces }}"
+
+  tasks:
+    - name: add extra packages
+      become: yes
+      yum:
+        name: jq
+        state: present


### PR DESCRIPTION
The snapshotting scripts under ansible/scripts
depend on jq being installed locally.