### PR TITLE
Allow choice of NIC for floating IP when multiple

### DIFF
--- a/ansible/roles/openstack-idr-instance/README.md
+++ b/ansible/roles/openstack-idr-instance/README.md
@@ -14,13 +14,19 @@ Required variables:
 - `idr_vm_image`: Openstack base image
 - `idr_vm_flavour`: Openstack flavour
 
-Optional variables:
+Optional instance variables:
 - `idr_environment`: Use this as a group prefix. This is required to ensure servers can lookup the address of other servers in the group, and is particularly important if multiple groups of servers are running in the same project. The default is `idr` but you should almost always set it to something else.
 - `idr_vm_keyname`: Openstack SSH key, defaults to `idr-deployment-key` (see the `openstack-idr-keypairs` role)
-- `idr_vm_private_networks`: Use this network instead of the default one
-- `idr_vm_assign_floating_ip`: Assign a floating IP, default `False`
 - `idr_vm_count`: Number of VMs to create, default `1`. The first VM will be named `idr_vm_name`, subsequent VMs will be named `idr_vm_name-N`
+
+Optional networking variables:
 - `idr_vm_networks`: A list of `net-name: NETWORK_NAME` pairs
+- `idr_vm_assign_floating_ip`: Assign a floating IP, default `False`.
+  If you have multiple NICs you should also define `idr_vm_floating_ip_net`.
+  If `idr_vm_count > 1` only the first VM will have a floating IP assigned.
+- `idr_vm_floating_ip_net`: If a floating IP is required attach it to this network. If you have multiple networks you should define this.
+- `idr_vm_external_network`: The name of the external network.
+  If `idr_vm_floating_ip_net` is defined you must also define this.
 
 Booleans indicating the purpose of this server:
 - If any of these are `True` they will be used to automatically set the security groups and host-groups for this VM, default `False`. Multiple may be set to `True` if a server has multiple purposes.

--- a/ansible/roles/openstack-idr-instance/defaults/main.yml
+++ b/ansible/roles/openstack-idr-instance/defaults/main.yml
@@ -15,6 +15,9 @@ idr_vm_networks:
 idr_vm_keyname: idr-deployment-key
 
 idr_vm_assign_floating_ip: False
+idr_vm_floating_ip_net: ""
+# Required if idr_vm_floating_ip_net is set
+#idr_vm_external_network:
 
 # idr_environment: All VMs will be put into this group
 idr_environment: idr

--- a/ansible/roles/openstack-idr-instance/tasks/floatingip.yml
+++ b/ansible/roles/openstack-idr-instance/tasks/floatingip.yml
@@ -1,0 +1,30 @@
+---
+# Handle floating IPs with multiple NICs
+# The os_floating_ip module may behave in an unexpected manner.
+# These tasks attempt to work around them.
+# Even so you may still see problem with Ansible 2.1, if so try 2.2 or 2.3
+
+- name: idr vm | floating ip
+  #os_floating_ip_ansible23:
+  os_floating_ip_ansible22:
+  #os_floating_ip:
+    fixed_address: "{{ vm.results[0].openstack.networks[idr_vm_floating_ip_net][0] }}"
+    #nat_destination: "{{ idr_vm_floating_ip_net }}"
+    # TODO: shade(1.13.1).OpenStackCloud.add_ips_to_server ignores
+    # `fixed_address` unless `network` is also given, even though it
+    # shouldn't be necessary
+    network: "{{ idr_vm_external_network }}"
+    reuse: "yes"
+    server: "{{ vm.results[0].openstack.id }}"
+    state: present
+    # Wait so that we can check the IP (Ansible docs are incorrect)
+    wait: True
+  register: fip
+
+- fail:
+    msg: >
+      Expected floating ip {{ fip.floating_ip.floating_ip_address }} =>
+      {{ vm.results[0].openstack.networks[idr_vm_floating_ip_net][0] }}
+      found => {{ fip.floating_ip.fixed_ip_address }}.
+      This may be an Ansible bug, try manually detaching and reattaching the floating IP to the corrrect fixed IP.
+  when: 'fip.floating_ip.fixed_ip_address != vm.results[0].openstack.networks[idr_vm_floating_ip_net][0]'

--- a/ansible/roles/openstack-idr-instance/tasks/main.yml
+++ b/ansible/roles/openstack-idr-instance/tasks/main.yml
@@ -7,6 +7,10 @@
 # to work as expected since the hostvar is persistent across tasks.
 # See defaults/main.yml for most of the logic.
 
+# If you have multiple networks with external connectivity you should specify
+# the network the floating should be atfached too, otherwise it may be random
+# which is almost certainly not what you want.
+
 - name: idr vm | create VM
   os_server:
     # Only add `-N` suffix for item>1
@@ -16,7 +20,7 @@
     key_name: "{{ idr_vm_keyname }}"
     flavor: "{{ idr_vm_flavour }}"
     nics: "{{ idr_vm_networks }}"
-    auto_ip: "{{ idr_vm_assign_floating_ip }}"
+    auto_ip: "{{ idr_vm_assign_floating_ip and (idr_vm_floating_ip_net | length == 0) }}"
     meta: >
       {{ dict([
           ("hostname", idr_vm_name),
@@ -29,3 +33,6 @@
     security_groups: "{{ idr_vm_security_groups | join(',') }}"
   register: vm
   with_sequence: "count={{ idr_vm_count }}"
+
+- include: floatingip.yml
+  when: 'idr_vm_assign_floating_ip and (idr_vm_floating_ip_net | length > 0)'


### PR DESCRIPTION
This was an attempt to control which network a floating ip is assigned to when an instance has multiple networks. I'm opening this PR as a reminder to consider rebasing to https://github.com/IDR/ansible-role-openstack-idr-instance

--exclude