### PR TITLE
IDR 0.3.2 updates for final release (IDR-0.3.2)

### DIFF
--- a/ansible/idr-playbooks/group_vars/omero-hosts.yml
+++ b/ansible/idr-playbooks/group_vars/omero-hosts.yml
@@ -7,7 +7,7 @@ omero_system_uid: 546
 
 omero_web_runtime_redis: True
 # This refers to a custom IDR release URL, not an official OMERO version
-omero_release: "0.3.1"
+omero_release: "0.3.2"
 ice_version: "3.6"
 omero_omego_additional_args: "--downloadurl https://downloads.openmicroscopy.org/idr"
 # Upgrades are normally disabled, uncomment if you want to upgrade OMERO:
@@ -28,7 +28,7 @@ omero_server_limit_nofile: 16384
 # mapr
 
 omero_web_app_packages:
-  - "omero-mapr==0.1.8"
+- "omero-mapr==0.1.9"
 omero_web_apps_add:
 - omero_mapr
 

--- a/ansible/idr-playbooks/group_vars/omero-hosts.yml
+++ b/ansible/idr-playbooks/group_vars/omero-hosts.yml
@@ -22,6 +22,7 @@ omero_web_public_password: "{{ idr_secret_omero_web_public_password | default('p
 
 omero_prestart_file: "{{ playbook_dir }}/files/IDR-OMERO-52-omero.j2"
 
+omero_server_limit_nofile: 16384
 
 ######################################################################
 # mapr

--- a/ansible/idr-playbooks/idr-01-install-idr.yml
+++ b/ansible/idr-playbooks/idr-01-install-idr.yml
@@ -8,4 +8,6 @@
 
 - include: idr-docker.yml
 
+- include: idr-downloads.yml
+
 - include: idr-proxy.yml

--- a/ansible/idr-playbooks/idr-downloads.yml
+++ b/ansible/idr-playbooks/idr-downloads.yml
@@ -1,0 +1,33 @@
+# Setup the IDR rsync download server
+
+# Load hostvars
+- hosts: "{{ idr_environment | default('idr') }}-database-hosts"
+
+
+# TODO: Use new download-hosts group to avoid coupling this to omero-hosts
+# https://trello.com/c/ztvftdc8/154-define-download-hosts-group-for-rsync-server
+#- hosts: "{{ idr_environment | default('idr') }}-download-hosts"
+- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+
+  roles:
+
+  - role: openmicroscopy.rsync-server
+    rsync_server_shares:
+    - name: omero
+      path: /data/OMERO
+      comment: /OMERO directory from the IDR
+    - name: sql
+      path: /srv/omero-sql
+      comment: PostgreSQL 9.4 database dump of the IDR
+
+  # TODO: Create DB dump file? Or should this be in another playbooks since
+  # it's not directly related to deployment?
+  # tasks:
+  # - name: Get database IP
+  #   set_fact:
+  #     omero_omero_host_ansible: >-
+  #       {{
+  #         hostvars[groups[
+  #           idr_environment | default('idr') + '-database-hosts'][0]]
+  #           ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
+  #       }}

--- a/ansible/idr-playbooks/idr-ebi-nfs.yml
+++ b/ansible/idr-playbooks/idr-ebi-nfs.yml
@@ -36,13 +36,19 @@
       path: "{{ local_filesets_sym | dirname }}"
       state: directory
 
+  # This is needed to prevent the next file task returning an error
+  - name: Check for existing filesets object
+    stat:
+      path: "{{ local_filesets_sym }}"
+    register: local_filesets_sym_st
+
   - name: Create filesets symlink
     become: yes
     file:
-      force: yes
       path: "{{ local_filesets_sym }}"
       src: "{{ nfs_filesets_dir }}"
       state: link
+    when: "{{ not local_filesets_sym_st.stat.exists }}"
 
 
   vars:

--- a/ansible/idr-playbooks/idr-networks.yml
+++ b/ansible/idr-playbooks/idr-networks.yml
@@ -7,6 +7,7 @@
 - hosts: "{{ idr_environment | default('idr') }}-bastion-hosts"
   roles:
   - role: network-cloud-interfaces
+    network_cloud_interface_regex: '^eth.*'
 
 # All other hosts (e.g. those requiring NFS access on a separate network)
 - hosts: >
@@ -14,3 +15,4 @@
     {{ idr_environment | default('idr') }}-a-hosts
   roles:
   - role: network-cloud-interfaces
+    network_cloud_interface_regex: '^eth.*'

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -30,7 +30,7 @@
 
 - name: java
   src: openmicroscopy.java
-  version: 1.0.0
+  version: 2.0.0
 
 - name: jekyll-build
   src: openmicroscopy.jekyll-build
@@ -58,7 +58,7 @@
 
 - name: network-cloud-interfaces
   src: openmicroscopy.network-cloud-interfaces
-  version: 1.0.0
+  version: 1.1.0
 
 - name: nfs-mount
   src: openmicroscopy.nfs-mount
@@ -90,7 +90,7 @@
 
 - name: omero-server
   src: openmicroscopy.omero-server
-  version: 1.0.0
+  version: 1.1.0
 
 - name: omero-web-runtime
   src: openmicroscopy.omero-web-runtime
@@ -110,6 +110,9 @@
 
 - name: redis
   src: openmicroscopy.redis
+  version: 1.0.0
+
+- src: openmicroscopy.rsync-server
   version: 1.0.0
 
 - name: samba-client


### PR DESCRIPTION
Final changes for release:
- Set IDR OMERO.server nofile limit to `16384`
- Bump omero and map versions
- Fixes for when a full redeployment is run against an existing active server
- Initial setup or rsync server (the database dump will need to be manually created in `/srv/sql`)

Todo: Update tags in requirements.yml from:
- [x] https://github.com/openmicroscopy/ansible-role-omero-server/pull/1
- [x] https://github.com/openmicroscopy/ansible-role-network-cloud-interfaces/pull/1
- [x] https://github.com/manics/ansible-role-rsync-server (requires https://github.com/openmicroscopy/ansible-role-selinux-utils/pulls to pass travis)

~~`diff --git a/ansible/requirements.yml b/ansible/requirements.yml`~~
