### PR TITLE
Ansible readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,28 @@
 # OME Infrastructure
 
-Tools, scripts and other systems infrastructure used to support the work of the OME http://www.openmicroscopy.org/
+Tools, scripts and other systems infrastructure used to support the work of OME (http://www.openmicroscopy.org/).
 
-Eventually this will be used for setting up production servers including OMERO instances.
-If you are interested in this work please be aware it is a relatively new initiative and still under development, so please [contact us](http://www.openmicroscopy.org/site/community) if you require more information.
-
+If you are interested in this work or require more information, please
+[contact us](http://www.openmicroscopy.org/site/community).
 
 [![Build Status](https://travis-ci.org/openmicroscopy/infrastructure.png)](http://travis-ci.org/openmicroscopy/infrastructure)
 
-## OME Ansible repository
+## Ansible
 
+OME uses Ansible extensively for deploying production services. Installation and usage instructions are
+provided in the [ansible README](ansible/README.md).
 
-This playbook uses Ansible 2.0 features. See
-[the Ansible documentation](http://docs.ansible.com/ansible/intro_installation.html)
-for full installation instructions.
+## OpenStack
 
-### Installation
+The [OpenStack docs](docs/openstack/idr-openstack.md) outline the installation of OpenStack
+which is running at the University of Dundee.
 
-- Create a virtual environment and install the Ansible requirements (including
-  `shade` for using with OpenStack):
+## GPFS
 
-        virtualenv ~/venvs/ansible
-        ~/venvs/ansible/bin/pip install -r requirements.txt
+[GPFS.md](docs/storage/gpfs.md) provides details on the configuration of GPFS that is used
+at the University of Dundee.
 
-- Clone this repository:
+---------
 
-        git clone https://github.com/openmicroscopy/infrastructure.git
-
-- Execute the following commands from the `ansible` subdirectory of the
-  infrastructure repository.
-
-- Clone the repository containing the inventory, host and group vars files.
-  Ansible will automatically look for `host_vars` and `group_vars`
-  directories in the parent directory of the inventory file. This should be
-  located at `../../ansible/inventory` such that `-i ../../ansible/inventory`
-  would be correct.
-
-### Examples
-
-In the following examples replace example-hosts with the private host inventory file
-
-Dry-run `ci-provision.yml` for all hosts listed in `ci-provision.yml`:
-- `-u` Login as this user
-- `--ask-become-pass` prompt for sudo password
-- `-C` Dry-run mode
-- `-v` Verbose (repeat to increase verbosity)
-
-Note this may fail since some tasks are dependent on others being completed:
-
-    ansible-playbook -u $USERNAME --ask-become-pass -C -v ci-provision.yml
-
-Run `provision.yml`:
-
-    ansible-playbook -u $USERNAME --ask-become-pass ci-provision.yml
-
-Run `provision.yml` for all subset of the hosts or groups listed in `provision.yml`:
-
-    ansible-playbook -u $USERNAME --ask-become-pass ci-provision.yml --limit $HOST_OR_GROUP_NAME
-
-List the hosts that would be targeted by a command, don't do anything else:
-
-    ansible-playbook ci-provision.yml --list-hosts
-
-
-Playbooks which do not alter hardware can often be tested in Docker instead of a full VM, for example by using the [omero-ssh](https://github.com/manics/ome-docker/blob/omero-ssh/omero-ssh/Dockerfile) image:
-
-    docker run -d omero-ssh
-    # Optional:
-    ssh-copy-id omero@172.17.1.1
-    # Pass -K if sudo requires a password, and -k if ssh keys aren't setup
-    ansible-playbook -i etc/test-hosts -u omero ci-deployment.yml -bv
+For further information, you may want to read the
+[Contributing to OME](https://www.openmicroscopy.org/site/support/contributing/) page.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -10,6 +10,14 @@ Most of these scripts should also work on other platforms, providing the VM is b
 
 To get started with a minimal OMERO server, see the example playbook in the [omero-server](https://github.com/openmicroscopy/ansible-role-omero-server) role.
 
+For more explanation on using Ansible in general, you may want to read:
+
+- [Getting started](../docs/ansible/installation.md): Installation docs and initial examples.
+- [Ansible](../docs/ansible/ansible.md): Overview of Ansible, the configuration management system.
+- [Example workflows](../docs/ansible/example_workflows.md): Examples of provisioning new hosts, and running Ansible playbooks.
+- [Contributing](../docs/ansible/contributing.md): Suggestions on submitting modifications and extensions to the OME ansible roles and playbooks.
+
+
 Roles
 -----
 
@@ -89,18 +97,10 @@ The OME community also provides roles. For example:
 
 If you would like to share your roles with other OME users, please open a PR against this file on GitHub.
 
+Playbooks
+---------
 
-Further reading
----------------
-
-- [Getting started](../docs/ansible/installation.md): Installation docs and initial examples.
-- [Ansible](../docs/ansible/ansible.md): Overview of Ansible, the configuration management system.
-- [Example workflows](../docs/ansible/example_workflows.md): Examples of provisioning new hosts, and running Ansible playbooks.
-- [Contributing](../docs/ansible/contributing.md): Suggestions on submitting modifications and extensions to the OME ansible roles and playbooks.
-
-
-IDR Systems Infrastructure (`idrsystems-*`)
--------------------------------------------
+### IDR Systems Infrastructure (`idrsystems-*`) ###
 
 These playbooks are for maintaining the bare-metal infrastructure for most of the IDR work.
 This primarily involves maintaining the servers and storage underlying the virtualisation platforms used for development and running of the actual IDR, and is inevitably tied to the hardware configurations of these servers as well as the configuration of other services provided by the parent institution.
@@ -113,8 +113,7 @@ This primarily involves maintaining the servers and storage underlying the virtu
   Since this attempts to install updates there may be changes even if the repository or inventory are unchanged.
 
 
-Dell Hardware (`hardware-dell`)
--------------------------------
+### Dell Hardware (`hardware-dell`) ###
 
 The playbooks in the `hardware-dell` directory can be used to help with installing Dell hardware maintenance, for instance DRAC and BIOS updates.
 Given the nature of these updates these playbooks should only be run when required, and consideration given to running against one host at a time.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -17,8 +17,7 @@ Roles for these playbooks can be found on http://galaxy.ansible.com or http://gi
 A list of most of the roles can be found in
 [ansible/requirements.yml](https://github.com/openmicroscopy/infrastructure/blob/master/ansible/requirements.yml).
 
-Partial list of core roles
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+### Partial list of core roles ###
 
  - openmicroscopy.docker
    ([GitHub](https://github.com/openmicroscopy/ansible-role-docker)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/docker/)):
@@ -60,8 +59,7 @@ Partial list of core roles
 Other core roles can be found under the [openmicroscopy](https://galaxy.ansible.com/openmicroscopy/) account on Galaxy.
 
 
-Development roles
-^^^^^^^^^^^^^^^^^
+### Development roles ###
 
 Roles which are not available on Galaxy should be considered in development. For exapmle:
 
@@ -78,8 +76,7 @@ Roles which are not available on Galaxy should be considered in development. For
    ([GitHub](https://github.com/openmicroscopy/ansible-role-reboot-server)):
    Reboot a server, optionally wait for it to return.
 
-Community roles
-^^^^^^^^^^^^^^^
+### Community roles ###
 
 The OME community also provides roles. For example:
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,29 +1,25 @@
 OME Ansible
 ===========
 
-This contains a variety of Ansible playbooks and roles, including example files for provisioning an OpenStack VM from scratch with OMERO using Ansible.
+This folder contains a variety of Ansible playbooks, including example files for provisioning an OpenStack VM from scratch with OMERO using Ansible.
 Most of these scripts should also work on other platforms, providing the VM is brought up by some other method.
 
 - Playbooks which start with `os` are OpenStack specific - the `os` stands for `OpenStack`.
 - Playbooks which start with `idr` are for the Image Data Repository.
 - Playbooks which start with `ci` are for OME continuous integration and build.
 
-To get started with a minimal OMERO server, use the example playbook in the [README.md of roles/omero-server](/roles/omero-server/README.md).
-
-
-Roles
------
-There are two roles directories.
-- `roles`: These are roles which are considered ready for use. Breaking changes to these roles will be minimised.
-- `roles-dev`: Roles which are still in development, or require special external configuration. These are not recommended for use.
+To get started with a minimal OMERO server, use the example playbook in the [omero-server](https://github.com/openmicroscopy/ansible-role-omero-server) role.
 
 
 OME OpenStack Ansible
 ----------------------
 
-For the OpenStack specific README, see: [Getting started with OME OpenStack Ansible](README-os.md)
-
-For the IDR specific OpenStack README, see: [IDR OpenStack](README-os-idr.md)
+- [Getting started](../docs/ansible/installation.md): Installation docs and initial examples.
+- [Ansible](../docs/ansible/ansible.md): Overview of Ansible, the configuration management system.
+- [Example workflows](../docs/ansible/example_workflows.md): Examples of provisioning new hosts, and running Ansible playbooks.
+- [Contributing](../docs/ansible/contributing.md): Suggestions on submitting modifications and extensions to the OME ansible roles and playbooks.
+- For the OpenStack specific README, see: [Getting started with OME OpenStack Ansible](README-os.md)
+- For the IDR specific OpenStack README, see: [IDR OpenStack](README-os-idr.md)
 
 
 IDR Systems Infrastructure (`idrsystems-*`)

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -8,7 +8,7 @@ Most of these scripts should also work on other platforms, providing the VM is b
 - Playbooks which start with `idr` are for the Image Data Repository.
 - Playbooks which start with `ci` are for OME continuous integration and build.
 
-To get started with a minimal OMERO server, use the example playbook in the [omero-server](https://github.com/openmicroscopy/ansible-role-omero-server) role.
+To get started with a minimal OMERO server, see the example playbook in the [omero-server](https://github.com/openmicroscopy/ansible-role-omero-server) role.
 
 Roles
 -----

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -13,11 +13,14 @@ To get started with a minimal OMERO server, use the example playbook in the [ome
 Roles
 -----
 
-Roles for these playbooks can be found on http://galaxy.ansible.com or http://github.com .
-A list of most of the roles can be found in
+Roles are "the Ansible way of bundling automation content and making it reusable." To keep playbooks
+as simple as possible, logic is refactored out into roles and versioned separately. A list of most
+of the roles can be found in
 [ansible/requirements.yml](https://github.com/openmicroscopy/infrastructure/blob/master/ansible/requirements.yml).
 
-### Partial list of core roles ###
+### on Ansible Galaxy ###
+
+This is a partial list of the roles that the OME team has released to Galaxy:
 
  - openmicroscopy.docker
    ([GitHub](https://github.com/openmicroscopy/ansible-role-docker)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/docker/)):
@@ -59,9 +62,9 @@ A list of most of the roles can be found in
 Other core roles can be found under the [openmicroscopy](https://galaxy.ansible.com/openmicroscopy/) account on Galaxy.
 
 
-### Development roles ###
+### on GitHub ###
 
-Roles which are not available on Galaxy should be considered in development. For exapmle:
+Roles which are not available on Galaxy should be considered in development. For example:
 
  - hosts-populate
    ([GitHub](https://github.com/openmicroscopy/ansible-role-hosts-populate)):
@@ -76,13 +79,15 @@ Roles which are not available on Galaxy should be considered in development. For
    ([GitHub](https://github.com/openmicroscopy/ansible-role-reboot-server)):
    Reboot a server, optionally wait for it to return.
 
-### Community roles ###
+### from the community ###
 
 The OME community also provides roles. For example:
 
  - hajaalin.truststore
    ([GitHub](https://github.com/hajaalin/ansible-role-truststore)/([Galaxy](https://galaxy.ansible.com/hajaalin/truststore/)):
    Install JKS TrustStore
+
+If you would like to share your roles with other OME users, please open a PR against this file on GitHub.
 
 
 Further reading

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -99,13 +99,6 @@ Further reading
 - [Contributing](../docs/ansible/contributing.md): Suggestions on submitting modifications and extensions to the OME ansible roles and playbooks.
 
 
-OME OpenStack Ansible
-----------------------
-
-- For the OpenStack specific README, see: [Getting started with OME OpenStack Ansible](README-os.md)
-- For the IDR specific OpenStack README, see: [IDR OpenStack](README-os-idr.md)
-
-
 IDR Systems Infrastructure (`idrsystems-*`)
 -------------------------------------------
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -11,19 +11,24 @@ Most of these scripts should also work on other platforms, providing the VM is b
 To get started with a minimal OMERO server, use the example playbook in the [omero-server](https://github.com/openmicroscopy/ansible-role-omero-server) role.
 
 
-OME OpenStack Ansible
-----------------------
+Further reading
+---------------
 
 - [Getting started](../docs/ansible/installation.md): Installation docs and initial examples.
 - [Ansible](../docs/ansible/ansible.md): Overview of Ansible, the configuration management system.
 - [Example workflows](../docs/ansible/example_workflows.md): Examples of provisioning new hosts, and running Ansible playbooks.
 - [Contributing](../docs/ansible/contributing.md): Suggestions on submitting modifications and extensions to the OME ansible roles and playbooks.
+
+
+OME OpenStack Ansible
+----------------------
+
 - For the OpenStack specific README, see: [Getting started with OME OpenStack Ansible](README-os.md)
 - For the IDR specific OpenStack README, see: [IDR OpenStack](README-os-idr.md)
 
 
 IDR Systems Infrastructure (`idrsystems-*`)
-===========================================
+-------------------------------------------
 
 These playbooks are for maintaining the bare-metal infrastructure for most of the IDR work.
 This primarily involves maintaining the servers and storage underlying the virtualisation platforms used for development and running of the actual IDR, and is inevitably tied to the hardware configurations of these servers as well as the configuration of other services provided by the parent institution.
@@ -37,7 +42,7 @@ This primarily involves maintaining the servers and storage underlying the virtu
 
 
 Dell Hardware (`hardware-dell`)
-===============================
+-------------------------------
 
 The playbooks in the `hardware-dell` directory can be used to help with installing Dell hardware maintenance, for instance DRAC and BIOS updates.
 Given the nature of these updates these playbooks should only be run when required, and consideration given to running against one host at a time.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -10,6 +10,83 @@ Most of these scripts should also work on other platforms, providing the VM is b
 
 To get started with a minimal OMERO server, use the example playbook in the [omero-server](https://github.com/openmicroscopy/ansible-role-omero-server) role.
 
+Roles
+-----
+
+Roles for these playbooks can be found on http://galaxy.ansible.com or http://github.com .
+A list of most of the roles can be found in
+[ansible/requirements.yml](https://github.com/openmicroscopy/infrastructure/blob/master/ansible/requirements.yml).
+
+Partial list of core roles
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ - openmicroscopy.docker
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-docker)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/docker/)):
+   Install upstream Docker
+ - openmicroscopy.haproxy
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-haproxy)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/haproxy/)):
+   HAProxy installation and configuration
+ - openmicroscopy.ice
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-ice)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/ice/)):
+   Install ZeroC Ice
+ - openmicroscopy.java
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-java)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/java/)):
+   Install a given JRE or JDK
+ - openmicroscopy.logrotate
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-logrotate)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/logrotate/)):
+   Customise log-rotation
+ - openmicroscopy.lvm-partition
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-lvm-partition)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/lvm-partition/)):
+   Create a formatted LVM volume
+ - openmicroscopy.munin
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-munin)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/munin/)):
+   Setup a Munin monitoring server
+ - openmicroscopy.nfs-mount
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-nfs-mount)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/nfs-mount/)):
+   Manage NFS4 mounts
+ - openmicroscopy.nginx
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-nginx)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/nginx/)):
+   Install upstream nginx
+ - openmicroscopy.postgresql
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-nginx)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/nginx/)):
+   Install upstream PostgreSQL
+ - openmicroscopy.redis
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-nginx)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/nginx/)):
+   Install redis
+ - openmicroscopy.sudoers
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-nginx)/[Galaxy](https://galaxy.ansible.com/openmicroscopy/nginx/)):
+   Configure sudoers
+
+Other core roles can be found under the [openmicroscopy](https://galaxy.ansible.com/openmicroscopy/) account on Galaxy.
+
+
+Development roles
+^^^^^^^^^^^^^^^^^
+
+Roles which are not available on Galaxy should be considered in development. For exapmle:
+
+ - hosts-populate
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-hosts-populate)):
+   Populates /etc/hosts with static addresses for a list of hostgroups
+ - omero-user
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-omero-user)):
+   Create OMERO user accounts and groups
+ - omero-web-apps
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-omero-web-apps)):
+   Install OMERO.web plugins
+ - reboot-server
+   ([GitHub](https://github.com/openmicroscopy/ansible-role-reboot-server)):
+   Reboot a server, optionally wait for it to return.
+
+Community roles
+^^^^^^^^^^^^^^^
+
+The OME community also provides roles. For example:
+
+ - hajaalin.truststore
+   ([GitHub](https://github.com/hajaalin/ansible-role-truststore)/([Galaxy](https://galaxy.ansible.com/hajaalin/truststore/)):
+   Install JKS TrustStore
+
 
 Further reading
 ---------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Ansible
 
 - [Ansible](ansible/ansible.md): Overview of Ansible, the configuration management system.
 - [Example workflows](ansible/example_workflows.md): Examples of provisioning new hosts, and running Ansible playbooks.
-- [Contributing](ansible/contributing.md): TODO
+- [Contributing](ansible/contributing.md): Suggestions on submitting modifications and extensions to the OME ansible roles and playbooks.
 
 
 Storage

--- a/docs/ansible/contributing.md
+++ b/docs/ansible/contributing.md
@@ -1,3 +1,13 @@
 # Contributing
 
-TODO: guidelines, code style, etc
+General guidelines for contributing to the Ansible-based
+infrastructure used by OME.
+
+* Roles
+  - SemVer is used for developing roles.
+  - Production roles should be distributed via Galaxy.
+  - Prefix variables should be prefixed with role names.
+  - Molecule should be used for testing complex roles.
+
+* Playbooks
+  - Prefer the long-format

--- a/docs/ansible/installation.md
+++ b/docs/ansible/installation.md
@@ -1,0 +1,62 @@
+## OME Ansible installation
+
+This repository uses Ansible 2.0 features. See
+[the Ansible documentation](http://docs.ansible.com/ansible/intro_installation.html)
+for full installation instructions.
+
+### Installation
+
+- Create a virtual environment and install the Ansible requirements (including
+  `shade` for using with OpenStack):
+
+        virtualenv ~/venvs/ansible
+        ~/venvs/ansible/bin/pip install -r requirements.txt
+
+- Clone this repository:
+
+        git clone https://github.com/openmicroscopy/infrastructure.git
+
+- Execute the following commands from the `ansible` subdirectory of the
+  infrastructure repository.
+
+- Clone the repository containing the inventory, host and group vars files.
+  Ansible will automatically look for `host_vars` and `group_vars`
+  directories in the parent directory of the inventory file. This should be
+  located at `../../ansible/inventory` such that `-i ../../ansible/inventory`
+  would be correct.
+
+### Examples
+
+In the following examples replace example-hosts with the private host inventory file
+
+Dry-run `ci-provision.yml` for all hosts listed in `ci-provision.yml`:
+- `-u` Login as this user
+- `--ask-become-pass` prompt for sudo password
+- `-C` Dry-run mode
+- `-v` Verbose (repeat to increase verbosity)
+
+Note this may fail since some tasks are dependent on others being completed:
+
+    ansible-playbook -u $USERNAME --ask-become-pass -C -v ci-provision.yml
+
+Run `provision.yml`:
+
+    ansible-playbook -u $USERNAME --ask-become-pass ci-provision.yml
+
+Run `provision.yml` for all subset of the hosts or groups listed in `provision.yml`:
+
+    ansible-playbook -u $USERNAME --ask-become-pass ci-provision.yml --limit $HOST_OR_GROUP_NAME
+
+List the hosts that would be targeted by a command, don't do anything else:
+
+    ansible-playbook ci-provision.yml --list-hosts
+
+
+Playbooks which do not alter hardware can often be tested in Docker instead of a full VM, for example by using the [omero-ssh](https://github.com/manics/ome-docker/blob/omero-ssh/omero-ssh/Dockerfile) image:
+
+    docker run -d omero-ssh
+    # Optional:
+    ssh-copy-id omero@172.17.1.1
+    # Pass -K if sudo requires a password, and -k if ssh keys aren't setup
+    ansible-playbook -i etc/test-hosts -u omero ci-deployment.yml -bv
+

--- a/docs/ansible/installation.md
+++ b/docs/ansible/installation.md
@@ -19,6 +19,10 @@ for full installation instructions.
 - Execute the following commands from the `ansible` subdirectory of the
   infrastructure repository.
 
+- Download the necessary Ansible roles:
+
+        ansible-galaxy install -r requirements.yml
+
 - Clone the repository containing the inventory, host and group vars files.
   Ansible will automatically look for `host_vars` and `group_vars`
   directories in the parent directory of the inventory file. This should be


### PR DESCRIPTION
This PR is intended to perform a couple of different cleanups and additions to the READMEs and docs in this repository post-migration to galaxy including:

 * [x] Remove mention of roles 
 * [x] Rework navigation (Reduce number of READMEs):
   - Top-level `README` points to ansible (once), gpfs, openstack (once)
   - `docs/README` points to each ansible (is this needed??)
   - `docs/ansible/` has no README
   - `ansible/README` points to `docs/ansible`
 * [x] https://trello.com/c/4Ubg1yGK/40-doc-new-role-locations
 * [x] https://github.com/openmicroscopy/infrastructure/pull/245