### PR TITLE
install nodejs 6.x

### DIFF
--- a/ansible/roles/omero-web-apps-build-dependencies/tasks/redhat.yml
+++ b/ansible/roles/omero-web-apps-build-dependencies/tasks/redhat.yml
@@ -20,7 +20,7 @@
 - name: Install nodejs
   become: yes
   yum:
-    enablerepo: epel-testing
+    enablerepo: epel
     name: nodejs
     state: present
 

--- a/ansible/roles/omero-web-apps-build-dependencies/tasks/redhat.yml
+++ b/ansible/roles/omero-web-apps-build-dependencies/tasks/redhat.yml
@@ -20,7 +20,8 @@
 - name: Install nodejs
   become: yes
   yum:
-    name: https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+    enablerepo: epel-testing
+    name: nodejs
     state: present
 
 - name: Install npm


### PR DESCRIPTION
Enable epel-testing to install nodejs 6.x

The change uses epel-testing repo to install nodejs 6.x
This will install v6.9.5

cc @joshmoore @kennethgillen 