### PR TITLE
ome-ns-web: Bumping OMERO.web release

### DIFF
--- a/ansible/server-state-playbooks/nightshade-web/playbook.yml
+++ b/ansible/server-state-playbooks/nightshade-web/playbook.yml
@@ -44,7 +44,7 @@
     # OMERO.web configuration in host_vars in different repository
     # Upgrade 5.2.8 Web to 5.3.0
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.3.0
+      omero_web_release: 5.3.1
       omero_web_upgrade: True
       no_log: true
 


### PR DESCRIPTION
Upgraded ns-web by re-running the `server-state-playbook` after bumping the OMERO.web version in the playbook.

Note, this did not work straight off, as the role which this playbook is using a hard-coded set of dependencies, rather than reading the `requirements.yml` shipped with the OMERO.web distribution. This will be fixed in the role with the inclusion of https://github.com/openmicroscopy/ansible-role-omero-web/pull/3/files

Run against ome-ns-web in check mode: [ns-web-531_upgrade-provision_20170426-164631Z.txt](https://github.com/openmicroscopy/infrastructure/files/962309/ns-web-531_upgrade-provision_20170426-164631Z.txt)

Run against ome-ns-web: [ns-web-531_upgrade-provision_20170426-164926Z.txt](https://github.com/openmicroscopy/infrastructure/files/962310/ns-web-531_upgrade-provision_20170426-164926Z.txt)

(i.e. live / in production)




