### PR TITLE
Attempt to provision non-vm docker jupyterhub

### DIFF
--- a/ansible/ome-analysis/ansible.cfg
+++ b/ansible/ome-analysis/ansible.cfg
@@ -1,0 +1,9 @@
+# Ansible configuration file
+
+[defaults]
+
+# Assume all actions take place under infrastructure/ansible/ome-analysis
+roles_path = vendor/:../roles/
+inventory = ../../../ansible/inventory/
+
+retry_files_enabled = False

--- a/ansible/ome-analysis/initial.yml
+++ b/ansible/ome-analysis/initial.yml
@@ -1,0 +1,16 @@
+---
+# Initial configuration of IDR nodes
+# Note you should reboot after changing the network configuration, and
+# manually verify that the configuration is correct
+
+- hosts: ome-jupyter
+  roles:
+  - role: openmicroscopy.upgrade-distpackages
+
+  # Fails due to yum excludes, install it manually if you want it:
+  # yum --disableexcludes=all install check-mk-agent-1.2.6p16
+  #- role: system-monitor-agent
+
+  post_tasks:
+  - debug:
+      msg: "You may need to reboot your system"

--- a/ansible/ome-analysis/ome-jupyter.yml
+++ b/ansible/ome-analysis/ome-jupyter.yml
@@ -1,0 +1,95 @@
+---
+# Playbook for setting up a jupyterhub server
+
+- hosts: ome-jupyter
+
+  roles:
+
+  # Do we need this?
+  #- role: server-swap
+
+  - role: network
+    # WARNING: ensure this server was provisioned with a statically assigned
+    # DHCP address, since these settings will be copied to a static
+    # configuration
+    network_ifaces:
+      - device: bond0
+        ip: "{{ ansible_default_ipv4.address }}"
+        netmask: "{{ ansible_default_ipv4.netmask }}"
+        type: bond
+        gateway: "{{ ansible_default_ipv4.gateway }}"
+        dns1: "{{ ansible_dns.nameservers.0 }}"
+        dns2: "{{ ansible_dns.nameservers.1 }}"
+        bondmaster: bond0
+      - device: eno1
+        bondmaster: bond0
+      - device: eno2
+        bondmaster: bond0
+    network_delete_ifaces: (enp|em).*
+
+  - role: openmicroscopy.lvm-partition
+    lvm_lvname: root
+    lvm_lvmount: /
+    lvm_lvsize: 20g
+    lvm_lvfilesystem: ext4
+    lvm_vgname: VolGroup00
+
+  - role: openmicroscopy.lvm-partition
+    lvm_lvname: var_log
+    lvm_lvmount: /var/log
+    lvm_lvsize: 4g
+    lvm_lvfilesystem: ext4
+    lvm_vgname: VolGroup00
+
+  - role: openmicroscopy.lvm-partition
+    lvm_lvname: var_lib_docker
+    lvm_lvmount: /var/lib/docker
+    lvm_lvsize: 1t
+    # Docker overlay requires d_type which isn't supported on RHEL7 xfs
+    # https://access.redhat.com/solutions/2322911
+    lvm_lvfilesystem: ext4
+    lvm_vgname: VolGroup00
+
+  - role: openmicroscopy.lvm-partition
+    lvm_lvname: data
+    lvm_lvmount: /data
+    lvm_lvsize: 1t
+    lvm_lvfilesystem: ext4
+    lvm_vgname: VolGroup00
+
+  - role: openmicroscopy.basedeps
+
+  - role: openmicroscopy.cli-utils
+
+  - role: openmicroscopy.versioncontrol-utils
+
+  # Ensure the system (especially kernel) is up to date
+  - role: openmicroscopy.docker
+
+  #- role: openmicroscopy.cadvisor
+
+  - role: IDR.idr-jupyter
+    idr_jupyter_hub_image: imagedata/jupyterhub-githubauth:latest
+    idr_jupyter_notebook_image: imagedata/jupyter-docker:latest
+    idr_jupyter_notebook_volumes: { '/data': '/data/notebooks' }
+
+  tasks:
+
+  - name: clone idr-notebooks
+    become: yes
+    git:
+      dest: "/data/"
+      repo: https://github.com/IDR/idr-notebooks.git
+      force: no
+      version: HEAD
+
+  - name: jupyterhub | create scratch notebooks directory
+    become: yes
+    file:
+      mode: "0755"
+      owner: 1000
+      path: "{{ idr_jupyter_notebook_host_volume }}/scratch"
+      state: directory
+
+  # Internal OME System monitoring: install manually
+  # yum --disableexcludes=all install check-mk-agent-1.2.6p16

--- a/ansible/ome-analysis/ome-jupyter.yml
+++ b/ansible/ome-analysis/ome-jupyter.yml
@@ -1,5 +1,10 @@
 ---
-# Playbook for setting up a jupyterhub server
+# This is an almost self-contained playbook for setting up a single
+# Jupyterhub server, with cadvisor running on port 9280
+# The only external variables are for GitHub OAuth.
+# In future if this is used to manage a cluster of Jupyterhub servers
+# some of the hardcode variables (e.g. volume sizes) should be moved into
+# group_vars
 
 - hosts: ome-jupyter
 
@@ -66,29 +71,33 @@
   # Ensure the system (especially kernel) is up to date
   - role: openmicroscopy.docker
 
-  #- role: openmicroscopy.cadvisor
+  - role: openmicroscopy.cadvisor
 
   - role: IDR.idr-jupyter
+    idr_jupyter_ip: "{{ ansible_default_ipv4.address }}"
     idr_jupyter_hub_image: imagedata/jupyterhub-githubauth:latest
     idr_jupyter_notebook_image: imagedata/jupyter-docker:latest
-    idr_jupyter_notebook_volumes: { '/data': '/data/notebooks' }
+    idr_jupyter_notebook_volumes: { '/data/idr-notebooks': '/notebooks' }
 
   tasks:
 
   - name: clone idr-notebooks
     become: yes
     git:
-      dest: "/data/"
+      dest: /data/idr-notebooks
       repo: https://github.com/IDR/idr-notebooks.git
       force: no
       version: HEAD
 
+  # Ideally scratch would be outside the github repo, but currently
+  # imagedata/jupyter-docker hardcodes /notebooks/library into the python
+  # path, so /data/idr-notebooks has to the the working directory
   - name: jupyterhub | create scratch notebooks directory
     become: yes
     file:
       mode: "0755"
       owner: 1000
-      path: "{{ idr_jupyter_notebook_host_volume }}/scratch"
+      path: /data/idr-notebooks/scratch
       state: directory
 
   # Internal OME System monitoring: install manually

--- a/ansible/ome-analysis/requirements.yml
+++ b/ansible/ome-analysis/requirements.yml
@@ -1,0 +1,48 @@
+# External Ansible roles required by this repository
+
+- src: openmicroscopy.basedeps
+  version: 1.0.0
+
+- src: openmicroscopy.cli-utils
+  version: 1.0.0
+
+- src: https://github.com/manics/ansible-role-cadvisor.git
+  name: openmicroscopy.cadvisor
+  version: 0.1.0
+
+- src: openmicroscopy.docker
+  version: 2.0.0
+
+- src: openmicroscopy.docker-tools
+  version: 1.0.0
+
+- src: openmicroscopy.logrotate
+  version: 1.0.0
+
+- src: openmicroscopy.lvm-partition
+  version: 1.0.0
+
+- src: openmicroscopy.nfs-mount
+  version: 1.0.0
+
+- src: openmicroscopy.nginx
+  version: 1.0.0
+
+- src: openmicroscopy.nginx-proxy
+  version: 1.0.0
+
+- src: openmicroscopy.selinux-utils
+  version: 1.0.1
+
+- src: openmicroscopy.sudoers
+  version: 1.0.0
+
+- src: openmicroscopy.upgrade-distpackages
+  version: 1.0.0
+
+- src: openmicroscopy.versioncontrol-utils
+  version: 1.0.0
+
+- name: IDR.idr-jupyter
+  src: https://github.com/IDR/ansible-role-idr-jupyter.git
+  version: 2.0.0

--- a/ansible/ome-analysis/requirements.yml
+++ b/ansible/ome-analysis/requirements.yml
@@ -6,8 +6,7 @@
 - src: openmicroscopy.cli-utils
   version: 1.0.0
 
-- src: https://github.com/manics/ansible-role-cadvisor.git
-  name: openmicroscopy.cadvisor
+- src: openmicroscopy.cadvisor
   version: 0.1.0
 
 - src: openmicroscopy.docker


### PR DESCRIPTION
A self-contained playbook for setting up JupyterHub on a physical host with a pre-existing LVM volume group. Also sets up cadvisor for container monitoring. `idr.connection` parameters are not configured by this playbook.