### PR TITLE
ome-dundeeomero provisioning development PR 

### DIFF
--- a/ansible/server-state-playbooks/ome-dundeeomero/README.txt
+++ b/ansible/server-state-playbooks/ome-dundeeomero/README.txt
@@ -1,8 +1,8 @@
-### Taken from manics/ansible-public-omero-example.git
-### at bc730e580e7c9ed0752a68cd4aa42397e4e58a2a
-### and stripped of server components, leaving just server.
+### Taken from openmicroscopy/ansible-public-omero-example.git
+### and stripped of web components, leaving just server.
 
 ### ansible playbooks & requirements for installing basic OMERO server.
+### addition of NGINX to proxy to a decoupled remote OMERO.web server.
 
 
 - playbooks set up to run from localhost rather than remotely

--- a/ansible/server-state-playbooks/ome-dundeeomero/README.txt
+++ b/ansible/server-state-playbooks/ome-dundeeomero/README.txt
@@ -1,0 +1,14 @@
+### Taken from manics/ansible-public-omero-example.git
+### at bc730e580e7c9ed0752a68cd4aa42397e4e58a2a
+### and stripped of server components, leaving just server.
+
+### ansible playbooks & requirements for installing basic OMERO server.
+
+
+- playbooks set up to run from localhost rather than remotely
+
+- after installing ansible and ansible-galaxy,
+    ansible-galaxy install -r requirements.yml -p roles
+
+- install OMERO server
+    ansible-playbook playbook.yml

--- a/ansible/server-state-playbooks/ome-dundeeomero/Vagrantfile
+++ b/ansible/server-state-playbooks/ome-dundeeomero/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    config.vm.network "forwarded_port", guest: 80, host: 8080
+    config.vm.network "forwarded_port", guest: 4064, host: 4064
+    config.vm.network "forwarded_port", guest: 4063, host: 4063
+  end
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "playbook.yml"
+    ansible.galaxy_role_file = "requirements.yml"
+  end
+end

--- a/ansible/server-state-playbooks/ome-dundeeomero/Vagrantfile
+++ b/ansible/server-state-playbooks/ome-dundeeomero/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "ansible" do |ansible|
+    ansible.skip_tags = "lvm"
     ansible.playbook = "playbook.yml"
     ansible.galaxy_role_file = "requirements.yml"
   end

--- a/ansible/server-state-playbooks/ome-dundeeomero/molecule.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: requirements.yml
+
+driver:
+  name: docker
+
+docker:
+  containers:
+  - name: omero-server
+    image: centos/systemd
+    image_version: latest
+    privileged: True
+
+ansible:
+  host_vars:
+    omero-server:
+      omero_server_systemd_require_network: False
+  verbose: True
+  diff: True
+
+verifier:
+  name: testinfra

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -24,7 +24,7 @@
       lvm_lvname: pgdata
       lvm_vgname: postgresql
       lvm_lvmount: /var/lib/pgsql
-      lvm_lvsize: "98%FREE"
+      lvm_lvsize: "74G"
       lvm_lvfilesystem: "{{ filesystem }}"
 
     # Disk Layout - OMERO | data dir 
@@ -33,7 +33,7 @@
       lvm_lvname: basedir
       lvm_vgname: omero
       lvm_lvmount: "{{ omero_common_basedir }}"
-      lvm_lvsize: "98%FREE"
+      lvm_lvsize: "10120M"
       lvm_lvfilesystem: "{{ filesystem }}"
 
     - role: openmicroscopy.postgresql

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -42,16 +42,39 @@
       - user: install-mock
         password: install-mock
         databases: [install-mock]
-      no_log: false
 
     # Testing with the NS copied data will require
     # a 5.2.x server, to be upgraded later.
+    # Note - had to have these set to `install-mock` to progress role
+    # installation before changing config to restored DB from other system.
     - role: openmicroscopy.omero-server
       omero_server_release: 5.2.8
-      omero_server_dbuser: install-mock
-      omero_server_dbname: install-mock
-      omero_server_dbpassword: install-mock
+      omero_server_dbuser: "{{ vault_omero_server_os_user }}"
+      omero_server_dbname:  "{{ vault_omero_server_dbname }}"
+      omero_server_dbpassword: "{{ vault_omero_server_dbpassword }}"
+      # Commenting out system_user: there's a bug in the role for 
+      # Active Directory users to be followed up.
+      # omero_server_system_user: "{{ vault_omero_server_os_user }}"
+      # omero_server_datadir: overridden after inital role run, via host vars
 
   vars:
     postgresql_version: "9.6"
     filesystem: "xfs"
+    omero_server_config_set:
+      omero.db.poolsize: 60
+      omero.jvmcfg.percent.blitz: 50
+      omero.jvmcfg.percent.indexer: 20
+      omero.jvmcfg.percent.pixeldata: 20
+      omero.jvmcfg.system_memory: 17000
+      omero.ldap.base: "{{ omero_server_ldap_base }}"
+      omero.ldap.config: true
+      omero.ldap.new_user_group: default
+      omero.ldap.urls: "{{ omero_server_ldap_urls }}"
+      omero.mail.config: true
+      omero.mail.from: "{{ omero_server_mail_from }}"
+      omero.mail.host: "{{ omero_server_mail_host }}"
+      omero.new_user_group: "My Data"
+      omero.search.batch: 100
+      omero.security.password_provider: chainedPasswordProvider431
+      omero.throttling.method_time.error: 60000
+ 

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -10,20 +10,42 @@
       when: >
            ((ansible_virtualization_type is defined)
            and (ansible_virtualization_type == "VMware"))
+
+    # Perhaps alter the role at https://github.com/openmicroscopy/ansible-role-lvm-partition/
+    # to make some of the variables non-required.
+    - name: Resize root FS without altering mount options
+      tags: lvm
+      become: yes
+      lvol:
+        lv: root
+        vg: rhel
+        size: "{{ provision_root_lvsize }}"
+        
+    - name: Install Make Movie script Prerequisite | MEncoder - Repo
+      become: yes
+      yum:
+        name:  http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+        state: present
+
+    - name: Install Make Movie script Prerequisite | MEncoder - Package
+      become: yes
+      yum:
+        name: mencoder
+        state: present
    
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server SLS` is checking for the SLS nameservers.
     - role: openmicroscopy.system-monitor-agent
       when: "'10.1.255.216' in ansible_dns.nameservers"
-
+   
     # Disk Layout - PostgreSQL | data dir  
     - role: openmicroscopy.lvm-partition
       tags: lvm
       lvm_lvname: pgdata
       lvm_vgname: postgresql
       lvm_lvmount: /var/lib/pgsql
-      lvm_lvsize: "74G"
+      lvm_lvsize: "{{ provision_postgres_lvsize }}"
       lvm_lvfilesystem: "{{ filesystem }}"
 
     # Disk Layout - OMERO | data dir 
@@ -32,7 +54,7 @@
       lvm_lvname: basedir
       lvm_vgname: omero
       lvm_lvmount: "{{ omero_common_basedir }}"
-      lvm_lvsize: "10120M"
+      lvm_lvsize: "{{ provision_omero_basedir_lvsize }}"
       lvm_lvfilesystem: "{{ filesystem }}"
       
     #  Mock database user & creds, to allow Playbook to install
@@ -52,7 +74,7 @@
       omero_server_dbuser: "{{ vault_omero_server_os_user }}"
       omero_server_dbname:  "{{ vault_omero_server_dbname }}"
       omero_server_dbpassword: "{{ vault_omero_server_dbpassword }}"
-      # Active Directory users not working with role
+      # Active Directory users not working with role.
       # Role requires to be manually modified to make it work with an AD user
       omero_server_system_user: "{{ vault_omero_server_os_user }}"
       # omero_server_datadir: overridden after inital role run, via host vars
@@ -61,6 +83,7 @@
     postgresql_version: "9.6"
     filesystem: "xfs"
     omero_server_config_set:
+      omero.db.name: omero
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
@@ -77,4 +100,6 @@
       omero.search.batch: 100
       omero.security.password_provider: chainedPasswordProvider431
       omero.throttling.method_time.error: 60000
+      omero.Ice.Default.Host: "{{ omero_server_ice_default_host }}"
+      Ice.Admin.Endpoints: "{{ omero_server_ice_admin_endpoints }}"
  

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -32,7 +32,16 @@
       yum:
         name: mencoder
         state: present
-   
+
+    - name: OMERO.figure server-side prerequisites 
+      become: yes
+      yum:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - python-reportlab 
+        - python-markdown 
+
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server SLS` is checking for the SLS nameservers.

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -18,15 +18,6 @@
     - role: openmicroscopy.system-monitor-agent
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
-    # test/prototype postgres being in a different location
-      become: yes
-      file:
-        dest: '/tmp/postgres-data-here/'
-        state: directory
-        mode: "u=rwx,go=rx" 
-        owner: "root" 
-        group: "root" 
-
     # Disk Layout - PostgreSQL | data dir 
     - role: openmicroscopy.lvm-partition
       tags: lvm
@@ -41,7 +32,7 @@
       tags: lvm
       lvm_lvname: basedir
       lvm_vgname: omero
-      lvm_lvmount: {{ omero_common_basedir }}
+      lvm_lvmount: "{{ omero_common_basedir }}"
       lvm_lvsize: "98%FREE"
       lvm_lvfilesystem: "{{ filesystem }}"
 

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -161,7 +161,7 @@
     postgresql_version: "9.6"
     filesystem: "xfs"
     omero_server_config_set:
-      omero.db.name: omero
+      omero.db.name: install-mock
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -131,19 +131,19 @@
     - role: openmicroscopy.omero-server
       omero_server_release: 5.3.1
       # install-mock set for inital provision, then playbook re-run with correct accounts.
-      omero_server_dbuser: install-mock
-      omero_server_dbname:  install-mock
-      omero_server_dbpassword: install-mock
-      #omero_server_dbuser: "{{ vault_omero_server_os_user }}"
-      #omero_server_dbname:  "{{ vault_omero_server_dbname }}"
-      #omero_server_dbpassword: "{{ vault_omero_server_dbpassword }}"
-      # Active Directory users not working with role, by default.
+      #omero_server_dbuser: install-mock
+      #omero_server_dbname:  install-mock
+      #omero_server_dbpassword: install-mock
+      omero_server_dbuser: "{{ vault_omero_server_os_user }}"
+      omero_server_dbname:  "{{ vault_omero_server_dbname }}"
+      omero_server_dbpassword: "{{ vault_omero_server_dbpassword }}"
+      # Active Directory users not working with role.
       # Role requires to be manually modified to make it work with an AD user
       omero_server_system_user: "{{ vault_omero_server_os_user }}"
       # Mocking omero_server_datadir for the first run.
       # Prod value to come from host vars
-      omero_server_datadir: "/tmp/install-mock_omero-server-datadir"
-      # omero_server_datadir: overridden after inital role run, via host vars
+      # omero_server_datadir: "/tmp/install-mock_omero-server-datadir"
+      # omero_server_datadir: overridden after inital role run via host vars
 
   post_tasks:
     - name: Check_MK postgres plugin | check for plugin existence

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -162,7 +162,6 @@
     postgresql_version: "9.6"
     filesystem: "xfs"
     omero_server_config_set:
-      omero.db.name: install-mock
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -1,7 +1,6 @@
 # Install OMERO.server and prepare the OME (UoD/SLS) prerequisites
 
 - hosts: all
-
   pre_tasks:
     - name: Install open-vm-tools if system is a VMware vm
       become: yes
@@ -18,7 +17,7 @@
     - role: openmicroscopy.system-monitor-agent
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
-    # Disk Layout - PostgreSQL | data dir 
+    # Disk Layout - PostgreSQL | data dir  
     - role: openmicroscopy.lvm-partition
       tags: lvm
       lvm_lvname: pgdata
@@ -35,26 +34,24 @@
       lvm_lvmount: "{{ omero_common_basedir }}"
       lvm_lvsize: "10120M"
       lvm_lvfilesystem: "{{ filesystem }}"
-
+      
+    #  Mock database user & creds, to allow Playbook to install
+    #  OMERO, and allow for a manual PostgresSQL dump/restore.
     - role: openmicroscopy.postgresql
       postgresql_users_databases:
-      - user: "{{ vault_omero_os_user }}" 
-        password:  "{{ vault_omero_db_password }}"
-        databases: [omero]
-
-    # Not sure if we can Ansible this step, but for a
-    # migration, restore the DB before deploying OMERO
-    # and don't try to fully create a new OMERO db. (OMEGO options?)
+      - user: install-mock
+        password: install-mock
+        databases: [install-mock]
+      no_log: false
 
     # Testing with the NS copied data will require
     # a 5.2.x server, to be upgraded later.
     - role: openmicroscopy.omero-server
       omero_server_release: 5.2.8
-      #NB - here must over-ride the omero OS user
-      # with that of Nightshade rather than the role default
+      omero_server_dbuser: install-mock
+      omero_server_dbname: install-mock
+      omero_server_dbpassword: install-mock
 
   vars:
-    # how about all non-private vars existing here
-    # since this is a public resource?
     postgresql_version: "9.6"
     filesystem: "xfs"

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -47,6 +47,12 @@
         # Current server proxies to a decoupled OMERO.web server
         # Initially replicate this setup, to minimise changes.
         - nginx
+        
+    - name: NGINX - enable service / start on boot
+      become: yes
+      systemd:
+        name: nginx
+        enabled: yes
 
     # post 2.3 'dest' should be renamed 'path'
     - name: NGINX - Performance tuning - worker processes

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -126,18 +126,23 @@
         password: install-mock
         databases: [install-mock]
 
-    # Testing with the NS copied data will require
-    # a 5.2.x server, to be upgraded later.
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.2.8
-      omero_server_dbuser: "{{ vault_omero_server_os_user }}"
-      omero_server_dbname:  "{{ vault_omero_server_dbname }}"
-      omero_server_dbpassword: "{{ vault_omero_server_dbpassword }}"
-      # Active Directory users not working with role.
+      omero_server_release: 5.3.1
+      # install-mock set for inital provision, then playbook re-run with correct accounts.
+      omero_server_dbuser: install-mock
+      omero_server_dbname:  install-mock
+      omero_server_dbpassword: install-mock
+      #omero_server_dbuser: "{{ vault_omero_server_os_user }}"
+      #omero_server_dbname:  "{{ vault_omero_server_dbname }}"
+      #omero_server_dbpassword: "{{ vault_omero_server_dbpassword }}"
+      # Active Directory users not working with role, by default.
       # Role requires to be manually modified to make it work with an AD user
       omero_server_system_user: "{{ vault_omero_server_os_user }}"
+      # Mocking omero_server_datadir for the first run.
+      # Prod value to come from host vars
+      omero_server_datadir: "/tmp/install-mock_omero-server-datadir"
       # omero_server_datadir: overridden after inital role run, via host vars
 
   post_tasks:

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -33,14 +33,66 @@
         name: mencoder
         state: present
 
-    - name: OMERO.figure server-side prerequisites 
+    - name: OMERO.figure server-side prerequisites, script prerequisites + web server for decoupled OMERO.web
       become: yes
       yum:
         name: "{{ item }}"
         state: present
       with_items:
+        # For OMERO.figure
         - python-reportlab 
         - python-markdown 
+        # For the 'make movie' script
+        - mencoder
+        # Current server proxies to a decoupled OMERO.web server
+        # Initially replicate this setup, to minimise changes.
+        - nginx
+
+    # post 2.3 'dest' should be renamed 'path'
+    - name: NGINX - Performance tuning - worker processes
+      become: yes
+      replace:
+        dest: "/etc/nginx/nginx.conf"
+        regexp: '^worker_processes\s+\d+;'
+        replace: "worker_processes 1;"
+
+    # post 2.3 'dest' should be renamed 'path'
+    # cf https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
+    - name: NGINX - Performance tuning - worker connections
+      become: yes
+      replace:
+        dest: "/etc/nginx/nginx.conf"
+        regexp: 'worker_connections\s+\d+;'
+        replace: "worker_connections 65000;"
+
+    - name: NGINX - SSL File Deployment - prepare directory
+      become: yes
+      file:
+        path: "{{ nginx_ssl_files_path }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "u=r,go=" 
+
+    - name: NGINX - SSL File Deployment
+      become: yes
+      copy:
+        dest="{{ item.key }}"
+        content="{{ item.value.content }}"
+        owner="{{ item.value.owner }}"
+        group="{{ item.value.group }}"
+        mode="{{ item.value.mode }}"
+      with_dict: "{{ nginx_ssl_cert_files }}"
+      no_log: true
+
+    # post 2.3 'destfile' should be renamed 'path'
+    - name: NGINX - Configuration 
+      become: yes
+      template:
+        src: nginx-omero.conf.j2
+        dest: /etc/nginx/conf.d/omero-web.conf
+      notify:
+        - restart nginx
 
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
@@ -87,7 +139,6 @@
       # Role requires to be manually modified to make it work with an AD user
       omero_server_system_user: "{{ vault_omero_server_os_user }}"
       # omero_server_datadir: overridden after inital role run, via host vars
-
 
   post_tasks:
     - name: Check_MK postgres plugin | check for plugin existence

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -88,7 +88,20 @@
       omero_server_system_user: "{{ vault_omero_server_os_user }}"
       # omero_server_datadir: overridden after inital role run, via host vars
 
+
+  post_tasks:
+    - name: Check_MK postgres plugin | check for plugin existence
+      stat:
+        path: "{{ check_mk_postgres_plugin }}"
+      register: check_mk_postgres_plugin_st
+
+    - name: Check_MK postgres plugin | activate the plugin
+      become: yes
+      command: cp "{{ check_mk_postgres_plugin }}"  /usr/share/check-mk-agent/plugins/
+      when: check_mk_postgres_plugin_st.stat.exists
+
   vars:
+    check_mk_postgres_plugin: /usr/share/check-mk-agent/available-plugins/mk_postgres
     postgresql_version: "9.6"
     filesystem: "xfs"
     omero_server_config_set:

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -144,6 +144,7 @@
       # Prod value to come from host vars
       # omero_server_datadir: "/tmp/install-mock_omero-server-datadir"
       # omero_server_datadir: overridden after inital role run via host vars
+      omero_server_systemd_limit_nofile: 16384
 
   post_tasks:
     - name: Check_MK postgres plugin | check for plugin existence

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -52,9 +52,9 @@
       omero_server_dbuser: "{{ vault_omero_server_os_user }}"
       omero_server_dbname:  "{{ vault_omero_server_dbname }}"
       omero_server_dbpassword: "{{ vault_omero_server_dbpassword }}"
-      # Commenting out system_user: there's a bug in the role for 
-      # Active Directory users to be followed up.
-      # omero_server_system_user: "{{ vault_omero_server_os_user }}"
+      # Active Directory users not working with role
+      # Role requires to be manually modified to make it work with an AD user
+      omero_server_system_user: "{{ vault_omero_server_os_user }}"
       # omero_server_datadir: overridden after inital role run, via host vars
 
   vars:

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -1,0 +1,69 @@
+# Install OMERO.server and prepare the OME (UoD/SLS) prerequisites
+
+- hosts: all
+
+  pre_tasks:
+    - name: Install open-vm-tools if system is a VMware vm
+      become: yes
+      yum:
+        name: open-vm-tools
+        state: latest
+      when: >
+           ((ansible_virtualization_type is defined)
+           and (ansible_virtualization_type == "VMware"))
+   
+  roles:
+    # Now OME are using RHEL without Spacewalk, the current best-method of
+    # checking `is server SLS` is checking for the SLS nameservers.
+    - role: openmicroscopy.system-monitor-agent
+      when: "'10.1.255.216' in ansible_dns.nameservers"
+
+    # test/prototype postgres being in a different location
+      become: yes
+      file:
+        dest: '/tmp/postgres-data-here/'
+        state: directory
+        mode: "u=rwx,go=rx" 
+        owner: "root" 
+        group: "root" 
+
+    # Disk Layout - PostgreSQL | data dir 
+    - role: openmicroscopy.lvm-partition
+      tags: lvm
+      lvm_lvname: pgdata
+      lvm_vgname: postgresql
+      lvm_lvmount: /var/lib/pgsql
+      lvm_lvsize: "98%FREE"
+      lvm_lvfilesystem: "{{ filesystem }}"
+
+    # Disk Layout - OMERO | data dir 
+    - role: openmicroscopy.lvm-partition
+      tags: lvm
+      lvm_lvname: basedir
+      lvm_vgname: omero
+      lvm_lvmount: {{ omero_common_basedir }}
+      lvm_lvsize: "98%FREE"
+      lvm_lvfilesystem: "{{ filesystem }}"
+
+    - role: openmicroscopy.postgresql
+      postgresql_users_databases:
+      - user: "{{ vault_omero_os_user }}" 
+        password:  "{{ vault_omero_db_password }}"
+        databases: [omero]
+
+    # Not sure if we can Ansible this step, but for a
+    # migration, restore the DB before deploying OMERO
+    # and don't try to fully create a new OMERO db. (OMEGO options?)
+
+    # Testing with the NS copied data will require
+    # a 5.2.x server, to be upgraded later.
+    - role: openmicroscopy.omero-server
+      omero_server_release: 5.2.8
+      #NB - here must over-ride the omero OS user
+      # with that of Nightshade rather than the role default
+
+  vars:
+    # how about all non-private vars existing here
+    # since this is a public resource?
+    postgresql_version: "9.6"
+    filesystem: "xfs"

--- a/ansible/server-state-playbooks/ome-dundeeomero/requirements.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/requirements.yml
@@ -1,0 +1,28 @@
+---
+
+- src: openmicroscopy.postgresql
+  version: 2.0.0
+
+- name: openmicroscopy.omero-common
+  src:  https://github.com/openmicroscopy/ansible-role-omero-common.git
+  version: 0.1.0
+
+- name: openmicroscopy.omego
+  src:  https://github.com/openmicroscopy/ansible-role-omego.git
+  version: 0.1.0
+
+- name: openmicroscopy.omero-server
+  src:  https://github.com/openmicroscopy/ansible-role-omero-server.git
+  version: 2.0.0-m1
+
+- name: omero-user
+  src: https://github.com/openmicroscopy/ansible-role-omero-user
+  version: 0.1.0
+
+- name: openmicroscopy.lvm-partition
+  src: https://github.com/openmicroscopy/ansible-role-lvm-partition.git
+
+- name: openmicroscopy.system-monitor-agent
+  src: https://github.com/openmicroscopy/ansible-role-system-monitor-agent.git
+
+

--- a/ansible/server-state-playbooks/ome-dundeeomero/templates/nginx-omero.conf.j2
+++ b/ansible/server-state-playbooks/ome-dundeeomero/templates/nginx-omero.conf.j2
@@ -36,7 +36,7 @@ server {
     location / {
         error_page 502 @maintenance;
         # return 502;
-        # checks for static file, if not found proxy to ns-web
+        # checks for static file, if not found proxy to {{ nginx_omero_web_server_address }}
     
         proxy_pass              {{ nginx_omero_web_server_address }};
         proxy_set_header        Host $host;

--- a/ansible/server-state-playbooks/ome-dundeeomero/templates/nginx-omero.conf.j2
+++ b/ansible/server-state-playbooks/ome-dundeeomero/templates/nginx-omero.conf.j2
@@ -1,0 +1,55 @@
+server {
+    listen 80;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name $hostname;
+
+    ssl_certificate {{ nginx_ssl_files_path }}/{{ nginx_ssl_cert_filename }};
+    ssl_certificate_key {{ nginx_ssl_files_path }}/{{ nginx_ssl_key_filename }};
+    ssl_protocols   {{ nginx_ssl_protocols }}
+
+    if ($ssl_protocol = "") {
+        rewrite ^/(.*) https://$host/$1 permanent;
+    }
+
+    # Add perfect forward secrecy
+    ssl_prefer_server_ciphers on;
+
+    # Add HSTS
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
+    # ciphers
+    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+
+    sendfile on;
+    client_max_body_size 0;
+
+    # maintenance page serve from here
+    location @maintenance {
+        root {{ omero_common_basedir }}/server/OMERO.server/etc/templates/error;
+        try_files $uri /maintainance.html =502;
+    }
+
+    location / {
+        error_page 502 @maintenance;
+        # return 502;
+        # checks for static file, if not found proxy to ns-web
+    
+        proxy_pass              {{ nginx_omero_web_server_address }};
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_connect_timeout   150;
+        proxy_send_timeout      100;
+        proxy_read_timeout      100;
+        proxy_buffers           4 32k;
+        client_max_body_size    8m;
+        client_body_buffer_size 128k;
+    }
+
+}
+

--- a/ansible/server-state-playbooks/ome-dundeeomero/tests/test_default.py
+++ b/ansible/server-state-playbooks/ome-dundeeomero/tests/test_default.py
@@ -1,0 +1,17 @@
+import testinfra.utils.ansible_runner
+import json
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+OMERO = '/opt/omero/web/OMERO.web/bin/omero'
+
+
+def test_omero_web_public(Command):
+    out = Command.check_output(
+        'curl http://localhost/webclient/api/containers/')
+    r = json.loads(out)
+    assert r['screens'] == []
+    assert r['plates'] == []
+    assert r['projects'] == []
+    assert r['datasets'] == []


### PR DESCRIPTION
Ongoing development work for migration of Dundee's OMERO server at 5.3 driven (mostly) via Ansible.

After manual provisioning of `.vmdk` and manual creation of the PVs...  

```
LS27172:ome-dundeeomero kenny$ ansible-playbook --diff -l ome-dundeeomero-test.openmicroscopy.org  -i ~/forks/management_tools/ansible/inventory/vagrant-test playbook.yml  --ask-vault-pass --ask-become-pass --tags=lvm
```

```
[root@ome-dundeeomero-test ~]# lvs
  LV      VG         Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  basedir omero      -wi-ao----  9.79g
  pgdata  postgresql -wi-ao---- 73.50g
  root    rhel       -wi-ao---- 13.39g
  swap    rhel       -wi-ao----  1.60g
[root@ome-dundeeomero-test ~]# ls /opt/omero/
[root@ome-dundeeomero-test ~]# df -h /opt/omero/
Filesystem                 Size  Used Avail Use% Mounted on
/dev/mapper/omero-basedir  9.8G   33M  9.8G   1% /opt/omero
[root@ome-dundeeomero-test ~]# ls /var/lib/pgsql/
[root@ome-dundeeomero-test ~]# df -h /var/lib/pgsql/
Filesystem                     Size  Used Avail Use% Mounted on
/dev/mapper/postgresql-pgdata   74G   33M   74G   1% /var/lib/pgsql
```