### PR TITLE
Nightshade 5.3.2 upgrade (ome-dundeeomero & ns-web)

### DIFF
--- a/ansible/server-state-playbooks/nightshade-web/playbook.yml
+++ b/ansible/server-state-playbooks/nightshade-web/playbook.yml
@@ -44,7 +44,7 @@
     # OMERO.web configuration in host_vars in different repository
     # Upgrade 5.2.8 Web to 5.3.0
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.3.1
+      omero_web_release: 5.3.2
       omero_web_upgrade: True
       no_log: true
 

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -135,7 +135,8 @@
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.3.1
+      omero_server_release: 5.3.2
+      omero_server_upgrade: True
       # install-mock set for inital provision, then playbook re-run with correct accounts.
       #omero_server_dbuser: install-mock
       #omero_server_dbname:  install-mock


### PR DESCRIPTION
tested in infra-testpr - produces an upgraded OMERO.web 5.3.2 server.