### PR TITLE
 ome-dundeeomero and nightshade-web to 5.3.3

### DIFF
--- a/ansible/server-state-playbooks/nightshade-web/playbook.yml
+++ b/ansible/server-state-playbooks/nightshade-web/playbook.yml
@@ -24,7 +24,7 @@
 
     # OMERO.web configuration in host_vars in different repository
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.3.2
+      omero_web_release: 5.3.3
       no_log: true
 
     # This to be refactored for RHEL/non-spacewalk at some point

--- a/ansible/server-state-playbooks/nightshade-web/playbook.yml
+++ b/ansible/server-state-playbooks/nightshade-web/playbook.yml
@@ -1,5 +1,5 @@
 # Install OMERO.web with a public user on localhost
-# Pass the command line 'upgrade-webapps' flag to upgrade webapps
+# Pass the command line 'upgrade_webapps' flag to upgrade webapps
 
 - hosts: all
 

--- a/ansible/server-state-playbooks/nightshade-web/templates/omero-web-config-for-webapps.j2
+++ b/ansible/server-state-playbooks/nightshade-web/templates/omero-web-config-for-webapps.j2
@@ -13,7 +13,7 @@ config append -- omero.web.open_with '["omero_fpbioimage", "fpbioimage_index", {
 
 # iviewer
 config append -- omero.web.apps '"omero_iviewer"'
-config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["image"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
+config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 
 # Autotag
 config append -- omero.web.apps '"omero_webtagging_autotag"'

--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -156,7 +156,7 @@
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.3.2
+      omero_server_release: 5.3.3
       # install-mock set for inital provision, then playbook re-run with correct accounts.
       #omero_server_dbuser: install-mock
       #omero_server_dbname:  install-mock


### PR DESCRIPTION
University of Dundee OMERO server ecosystem, known as "Nightshade", upgraded to 5.3.3, with the latest versions of the OMERO.web apps distributed via pypi.

Internal OME Trello card: https://trello.com/c/kW9gdajk/21-production-server-upgrades