### PR TITLE
ome-dundeeomero backup script Fix: can't use sudo from /etc/cron

### DIFF
--- a/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
+++ b/ansible/server-state-playbooks/ome-dundeeomero/playbook.yml
@@ -185,6 +185,7 @@
       when: check_mk_postgres_plugin_st.stat.exists
 
     - name: PostgreSQL Nightly Backups | Create the backups directory
+      tags: backups
       become: yes
       file:
         path: "{{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}"
@@ -194,6 +195,7 @@
         mode: "u=rwx,go="
 
     - name: PostgreSQL Nightly Backups | send the backup script
+      tags: backups
       become: yes
       template:
         src: nightly-pg_dump-omero.sh.j2

--- a/ansible/server-state-playbooks/ome-dundeeomero/templates/nightly-pg_dump-omero.sh.j2
+++ b/ansible/server-state-playbooks/ome-dundeeomero/templates/nightly-pg_dump-omero.sh.j2
@@ -2,4 +2,4 @@
 # Clean the files from the folder-format dump directory 
 rm {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}/* 
 # Create a fresh db dump
-sudo -u postgres pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} {{ vault_omero_server_dbname }}
+su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} {{ vault_omero_server_dbname }}'


### PR DESCRIPTION
An update to address the fact that the nightly backup was failing, though testing at the shell was successful.

Check mode against `ome-dundeeomero`: [ansible_run-backup-script-CHECK-ome-dundeeomero_20170704-120625Z.txt](https://github.com/openmicroscopy/infrastructure/files/1121987/ansible_run-backup-script-CHECK-ome-dundeeomero_20170704-120625Z.txt)

Live run against `ome-dundeeomero`: [ansible_run-backup-script-UPDATE-ome-dundeeomero_20170704-120909Z.txt](https://github.com/openmicroscopy/infrastructure/files/1121988/ansible_run-backup-script-UPDATE-ome-dundeeomero_20170704-120909Z.txt)

Without this PR
```
[root@ome-dundeeomero cron.daily]# run-parts  /etc/cron.daily/ -v
[root@ome-dundeeomero cron.daily]# du -sh /backups/*
64K    /backups/nightly-pg_dump_omero.dir
```


With this PR
```
[root@ome-dundeeomero cron.daily]# run-parts  /etc/cron.daily/ -v
[root@ome-dundeeomero cron.daily]# du -sh /backups/*
1.7G    /backups/nightly-pg_dump_omero.dir
```