### PR TITLE
Ara: add plugin to default configuration

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -28,7 +28,9 @@ inventory_ignore_extensions = ~, .orig, .bak, .ini, .retry, .pyc, .pyo, .html, .
 #callback_whitelist = profile_tasks
 
 # Additional plugins
-callback_plugins = ./plugins/callback
+callback_whitelist = ara
+callback_plugins = ./plugins/callback:$VIRTUAL_ENV/lib/python2.7/site-packages/ara/plugins/callbacks
+
 
 # Performance options
 [ssh_connection]


### PR DESCRIPTION
If ara is not installed, this should produce no change in behavior.

If ara *is* installed, then all calls to `ansible-playbook` will be
recorded to an sqlite database in ~/.ara/.

If additionally, ARA_DATABASE is configured to point at a shared
database, then all runs of ansible-playbook will be centrally recorded.