### PR TITLE
www-dev: improve Jekyll redeployment

### DIFF
--- a/ansible/server-state-playbooks/www-dev/www-dev.yml
+++ b/ansible/server-state-playbooks/www-dev/www-dev.yml
@@ -2,6 +2,8 @@
 
 # hosts: all for vagrant testing
 - hosts: infra-testpr.openmicroscopy.org
+  environment:
+      PATH: /usr/local/bin:{{ ansible_env.PATH }}
   pre_tasks:
     - name: Install open-vm-tools if system is a VMware vm
       become: yes
@@ -23,46 +25,6 @@
         size: "{{ provision_root_lvsize }}"
         shrink: no
 
-    - name: Jekyll Prerequisites | Ruby
-      become: yes
-      yum:
-        name: "{{ item }}"
-        state: present
-      with_items:
-        - ruby
-        - ruby-devel
-        - zlib-devel
-        - "@Development tools"
-
-    - name: Jekyll/Travis Prerequisites | Prerequisite Gems
-      become: yes
-      gem:
-        name: jekyll-feed
-        version: 0.7
-
-    - name: Jekyll/Travis Prerequisites | Prerequisite Gems
-      become: yes
-      gem:
-        name: nokogiri
-        version: 1.6.8.1
-
-    - name: Jekyll/Travis Prerequisites | Prerequisite Gems
-      become: yes
-      gem:
-        name: activesupport
-        version: 4.2.9
-
-    - name: Jekyll/Travis Prerequisites | Prerequisite Gems
-      become: yes
-      gem:
-        name: html-proofer
-        version: 3.2.0
-
-    - name: Jekyll/Travis Prerequisites | Prerequisite Gems
-      become: yes
-      gem:
-        name: jekyll-paginate
-        version: 1.1.0
 
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of

--- a/ansible/server-state-playbooks/www-dev/www-dev.yml
+++ b/ansible/server-state-playbooks/www-dev/www-dev.yml
@@ -46,6 +46,7 @@
     # and we are also using it in the config for role openmicroscopy.jekyll-build
     - name: Deployed HTML Symlink
       become: yes
+      tags: jekyll
       file:
         src: /var/www/localhost/html/
         path: /var/www/localhost/html/www.openmicroscopy.org


### PR DESCRIPTION
This PR follows up on #281 and addresses the issue captured in https://github.com/openmicroscopy/ansible-role-jekyll-build/issues/3 at the playbook level

The main problem is that `bundle` is not on the default `PATH` failing the `bundle install` handler in the `openmicroscopy.jekyll-build` role. This PR prepends `/usr/local/bin` to the PATH and adds the symlink step to the `jekyll` tag.

With this PR included, there should be no more need for the playbook to be executed twivewhen the Jekyll source code is changed. Additionally, the dependencies can be removed from the playbook and managed solely by the `Gemfile` of the source code and the `bundle install` handler.

To test this PR:

- from a reverted snapshot of the deployment Vm, run `ansible-playbook --ask-become-pass server-state-playbooks/www-dev/www-dev.yml` and check the new website is deployed in a single playbook execution
- add `jekyll_build_git_branch` to `www-dev.yml` to point at an earlier commit/tag, run `ansible-playbook --ask-become-pass server-state-playbooks/www-dev/www-dev.yml --tags=jekyll` and check that the new version deploys in a single execution