### PR TITLE
Consume 1.2.0 version of the jekyll-build role

### DIFF
--- a/ansible/server-state-playbooks/www/requirements.yml
+++ b/ansible/server-state-playbooks/www/requirements.yml
@@ -13,8 +13,8 @@
   version: 1.0.3
 
 - name: openmicroscopy.jekyll-build
-  src: https://github.com/snoopycrimecop/ansible-role-jekyll-build.git
-  version: master/merge/daily
+  src: https://github.com/openmicroscopy/ansible-role-jekyll-build.git
+  version: 1.2.0
 
 - name: openmicroscopy.lvm-partition
   src: https://github.com/openmicroscopy/ansible-role-lvm-partition.git


### PR DESCRIPTION
This version contains the improvements allowing to use multiple configuration
files and should be required for deploying the website.