### PR TITLE
2g max body size for QA

### DIFF
--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -96,7 +96,7 @@
       nginx_proxy_force_ssl: False
       nginx_proxy_404: "/404.html"
       nginx_proxy_conf_http:
-        - "client_max_body_size 2g;"
+        - "client_max_body_size 2g"
 
   post_tasks:
     - name: NGINX - Performance tuning - worker processes

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -95,9 +95,12 @@
       nginx_proxy_http2: True
       nginx_proxy_force_ssl: False
       nginx_proxy_404: "/404.html"
+      nginx_proxy_conf_http:
+        - "client_max_body_size 2g;"
 
   post_tasks:
     - name: NGINX - Performance tuning - worker processes
+      tags: nginxconf
       become: yes
       replace:
         path: "/etc/nginx/nginx.conf"
@@ -106,6 +109,7 @@
 
     # cf https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
     - name: NGINX - Performance tuning - worker connections
+      tags: nginxconf
       become: yes
       replace:
         path: "/etc/nginx/nginx.conf"


### PR DESCRIPTION
Requires: https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/10 

Specific to the QA app, uploading a 2G file, the uploader doesn't send 2G to `ome-www(-dev)` straight away, but the first request seems to contain the request size of the total upload, which `ome-www(-dev)` instantly writes an error log message, then follows up to the client after 30s with `HTTP Error 413 Request entity too large`. 

This seems to fix this behaviour.