### PR TITLE
Pin openmicroscopy.postgresql to 2.0.0

### DIFF
--- a/ansible/requirements-compat.yml
+++ b/ansible/requirements-compat.yml
@@ -102,7 +102,7 @@
 
 - name: postgresql
   src: openmicroscopy.postgresql
-  version: 1.0.0
+  version: 2.0.0
 
 - name: python-pydata
   src: openmicroscopy.python-pydata

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -79,7 +79,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.postgresql
-  version: 1.0.0
+  version: 2.0.0
 
 - src: openmicroscopy.python-pydata
   version: 1.0.0


### PR DESCRIPTION
While the PG role undergoes a few milestones for
the new 3.0 version, pin all requirements to the
latest stable, 2.0.0.

See https://github.com/openmicroscopy/ansible-role-postgresql/pull/6