### PR TITLE
Security redirects

### DIFF
--- a/ansible/server-state-playbooks/www/tests/check_redirects.py
+++ b/ansible/server-state-playbooks/www/tests/check_redirects.py
@@ -33,14 +33,14 @@ redirect_uris = [
     ('/site/products/omero', '/omero'),
     ('/site/products/omero/downloads', '/omero/downloads'),
     ('/site/products/omero/feature-list', '/omero/new'),
-    ('/site/products/omero/secvuln', '/security'),
-    ('/site/products/omero/secvuln/2014-SV3-csrf', '/security/2014-SV3-csrf'),
+    ('/site/products/omero/secvuln', '/security/'),
+    ('/site/products/omero/secvuln/2014-SV3-csrf', '/security/2014-SV3-csrf/'),
 
     ('/site/support', '/docs'),
     ('/site/news', '/announcements'),
 
-    ('/info/vulnerabilities', '/security'),
-    ('/info/vulnerabilities/2014-SV3-csrf', '/security/2014-SV3-csrf'),
+    ('/info/vulnerabilities', '/security/'),
+    ('/info/vulnerabilities/2014-SV3-csrf', '/security/2014-SV3-csrf/'),
 ]
 blog_uris = ('/omero-blog', 'http://blog.openmicroscopy.org')
 legacy_uris = [

--- a/ansible/server-state-playbooks/www/tests/check_redirects.py
+++ b/ansible/server-state-playbooks/www/tests/check_redirects.py
@@ -29,7 +29,9 @@ redirect_uris = [
 
     ('/site/products', '/products'),
     ('/site/products/bio-formats', '/bio-formats'),
+    ('/site/products/bio-formats/downloads', '/bio-formats/downloads'),
     ('/site/products/omero', '/omero'),
+    ('/site/products/omero/downloads', '/omero/downloads'),
     ('/site/products/omero/feature-list', '/omero/new'),
 
     ('/site/support', '/docs'),

--- a/ansible/server-state-playbooks/www/tests/check_redirects.py
+++ b/ansible/server-state-playbooks/www/tests/check_redirects.py
@@ -33,14 +33,16 @@ redirect_uris = [
     ('/site/products/omero', '/omero'),
     ('/site/products/omero/downloads', '/omero/downloads/'),
     ('/site/products/omero/feature-list', '/omero/new'),
-    ('/site/products/omero/secvuln', '/security/'),
-    ('/site/products/omero/secvuln/2014-SV3-csrf', '/security/2014-SV3-csrf/'),
+    ('/site/products/omero/secvuln', '/security/advisories/'),
+    ('/site/products/omero/secvuln/2014-SV3-csrf',
+     '/security/advisories/2014-SV3-csrf/'),
 
     ('/site/support', '/docs'),
     ('/site/news', '/announcements'),
 
-    ('/info/vulnerabilities', '/security/'),
-    ('/info/vulnerabilities/2014-SV3-csrf', '/security/2014-SV3-csrf/'),
+    ('/info/vulnerabilities', '/security/advisories/'),
+    ('/info/vulnerabilities/2014-SV3-csrf',
+     '/security/advisories/2014-SV3-csrf/'),
 ]
 blog_uris = ('/omero-blog', 'http://blog.openmicroscopy.org')
 legacy_uris = [

--- a/ansible/server-state-playbooks/www/tests/check_redirects.py
+++ b/ansible/server-state-playbooks/www/tests/check_redirects.py
@@ -29,9 +29,9 @@ redirect_uris = [
 
     ('/site/products', '/products'),
     ('/site/products/bio-formats', '/bio-formats'),
-    ('/site/products/bio-formats/downloads', '/bio-formats/downloads'),
+    ('/site/products/bio-formats/downloads', '/bio-formats/downloads/'),
     ('/site/products/omero', '/omero'),
-    ('/site/products/omero/downloads', '/omero/downloads'),
+    ('/site/products/omero/downloads', '/omero/downloads/'),
     ('/site/products/omero/feature-list', '/omero/new'),
     ('/site/products/omero/secvuln', '/security/'),
     ('/site/products/omero/secvuln/2014-SV3-csrf', '/security/2014-SV3-csrf/'),

--- a/ansible/server-state-playbooks/www/tests/check_redirects.py
+++ b/ansible/server-state-playbooks/www/tests/check_redirects.py
@@ -33,9 +33,14 @@ redirect_uris = [
     ('/site/products/omero', '/omero'),
     ('/site/products/omero/downloads', '/omero/downloads'),
     ('/site/products/omero/feature-list', '/omero/new'),
+    ('/site/products/omero/secvuln', '/security'),
+    ('/site/products/omero/secvuln/2014-SV3-csrf', '/security/2014-SV3-csrf'),
 
     ('/site/support', '/docs'),
     ('/site/news', '/announcements'),
+
+    ('/info/vulnerabilities', '/security'),
+    ('/info/vulnerabilities/2014-SV3-csrf', '/security/2014-SV3-csrf'),
 ]
 blog_uris = ('/omero-blog', 'http://blog.openmicroscopy.org')
 legacy_uris = [
@@ -49,7 +54,6 @@ legacy_uris = [
     '/site/community/minutes/conference-calls/2017',
     '/site/products/ome-tiff',
     '/site/products/partner',
-    '/site/products/omero/secvuln',
     '/site/products/ome5',
     '/site/support/omero5.3',
     '/site/support/bio-formats5.5',

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -181,7 +181,7 @@
       dest: /404.html
     - match: "~/info/?$"
       dest: /
-    - match: "~/info/vulnerabilities(?<link>/?.*)$"
+    - match: "~/info/vulnerabilities(?<link>.*)$"
       dest: /security$link
     - match: "~/info/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/info/$link
@@ -217,7 +217,7 @@
       dest: /omero/new
     - match: "~/site/products/omero/big-images-support/?$"
       dest: /omero/view/
-    - match: "~/site/products/omero/secvuln(?<link>/?.*)$"
+    - match: "~/site/products/omero/secvuln(?<link>.*)$"
       dest: /security$link
     - match: "~/site/products/bio-formats/?$"
       dest: /bio-formats

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -181,8 +181,10 @@
       dest: /404.html
     - match: "~/info/?$"
       dest: /
-    - match: "~/info/vulnerabilities(?<link>.*)$"
-      dest: /security$link
+    - match: "~/info/vulnerabilities/?$"
+      dest: /security/
+    - match: "~/info/vulnerabilities/(?<link>.*[^/])/?$"
+      dest: /security/$link/
     - match: "~/info/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/info/$link
     - match: "~/omero-blog.*"
@@ -217,8 +219,10 @@
       dest: /omero/new
     - match: "~/site/products/omero/big-images-support/?$"
       dest: /omero/view/
-    - match: "~/site/products/omero/secvuln(?<link>.*)$"
-      dest: /security$link
+    - match: "~/site/products/omero/secvuln/?$"
+      dest: /security/
+    - match: "~/site/products/omero/secvuln/(?<link>.*[^/])/?$"
+      dest: /security/$link/
     - match: "~/site/products/bio-formats/?$"
       dest: /bio-formats
     - match: "~/site/products/bio-formats/downloads/?$"

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -209,12 +209,16 @@
       dest: /products
     - match: "~/site/products/omero/?$"
       dest: /omero
+    - match: "~/site/products/omero/downloads/?$"
+      dest: /omero/downloads
     - match: "~/site/products/omero/feature-list/?$"
       dest: /omero/new
     - match: "~/site/products/omero/big-images-support/?$"
       dest: /omero/view/
     - match: "~/site/products/bio-formats/?$"
       dest: /bio-formats
+    - match: "~/site/products/bio-formats/downloads/?$"
+      dest: /bio-formats/downloads
     - match: "~/site/products/ome-files-cpp/?$"
       dest: /ome-files
     - match: "~/site/products/(?<link>.*)$"

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -214,7 +214,7 @@
     - match: "~/site/products/omero/?$"
       dest: /omero
     - match: "~/site/products/omero/downloads/?$"
-      dest: /omero/downloads
+      dest: /omero/downloads/
     - match: "~/site/products/omero/feature-list/?$"
       dest: /omero/new
     - match: "~/site/products/omero/big-images-support/?$"
@@ -226,7 +226,7 @@
     - match: "~/site/products/bio-formats/?$"
       dest: /bio-formats
     - match: "~/site/products/bio-formats/downloads/?$"
-      dest: /bio-formats/downloads
+      dest: /bio-formats/downloads/
     - match: "~/site/products/ome-files-cpp/?$"
       dest: /ome-files
     - match: "~/site/products/(?<link>.*)$"

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -181,6 +181,8 @@
       dest: /404.html
     - match: "~/info/?$"
       dest: /
+    - match: "~/info/vulnerabilities(?<link>/?.*)$"
+      dest: https://www.openmicroscopy.org/security$link
     - match: "~/info/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/info/$link
     - match: "~/omero-blog.*"
@@ -215,6 +217,8 @@
       dest: /omero/new
     - match: "~/site/products/omero/big-images-support/?$"
       dest: /omero/view/
+    - match: "~/site/products/omero/secvuln(?<link>/?.*)$"
+      dest: /security$link
     - match: "~/site/products/bio-formats/?$"
       dest: /bio-formats
     - match: "~/site/products/bio-formats/downloads/?$"

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -182,7 +182,7 @@
     - match: "~/info/?$"
       dest: /
     - match: "~/info/vulnerabilities(?<link>/?.*)$"
-      dest: https://www.openmicroscopy.org/security$link
+      dest: /security$link
     - match: "~/info/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/info/$link
     - match: "~/omero-blog.*"

--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -182,9 +182,9 @@
     - match: "~/info/?$"
       dest: /
     - match: "~/info/vulnerabilities/?$"
-      dest: /security/
+      dest: /security/advisories/
     - match: "~/info/vulnerabilities/(?<link>.*[^/])/?$"
-      dest: /security/$link/
+      dest: /security/advisories/$link/
     - match: "~/info/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/info/$link
     - match: "~/omero-blog.*"
@@ -220,9 +220,9 @@
     - match: "~/site/products/omero/big-images-support/?$"
       dest: /omero/view/
     - match: "~/site/products/omero/secvuln/?$"
-      dest: /security/
+      dest: /security/advisories/
     - match: "~/site/products/omero/secvuln/(?<link>.*[^/])/?$"
-      dest: /security/$link/
+      dest: /security/advisories/$link/
     - match: "~/site/products/bio-formats/?$"
       dest: /bio-formats
     - match: "~/site/products/bio-formats/downloads/?$"


### PR DESCRIPTION
This PR contains the necessary playbook adjustements as well as tests updating the OME Website redirects for the new security advisories pages:

- https://www.openmicroscopy.org/security/
- https://www.openmicroscopy.org/security/advisories/
- https://www.openmicroscopy.org/security/advisories/2012-SV1-ldap-authentication/
- https://www.openmicroscopy.org/security/advisories/2014-SV1-unicode-passwords/
- https://www.openmicroscopy.org/security/advisories/2014-SV2-empty-passwords/
- https://www.openmicroscopy.org/security/advisories/2014-SV3-csrf/
- https://www.openmicroscopy.org/security/advisories/2014-SV4-poodle/
- https://www.openmicroscopy.org/security/advisories/2016-SV1-cleanse/
- https://www.openmicroscopy.org/security/advisories/2016-SV2-share/
- https://www.openmicroscopy.org/security/advisories/2017-SV1-filename/
- https://www.openmicroscopy.org/security/advisories/2017-SV2-edit-rw/
- https://www.openmicroscopy.org/security/advisories/2017-SV3-delete-script/

Included is also a simpler redirect for the OMERO/Bio-Formats downloads pages rather but this can be split out to a different PR if needed.

## Deployment

For testing purposes this PR should be be deployed against `ome-www-dev.openmicroscopy.org` using:

```
ansible-playbook --ask-become server-state-playbooks/www/www.yml -l ome-www-dev.openmicroscopy.org
```

## Testing

After running the playbook, the following URLs should be tested manually

- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2012-SV1-ldap-authentication/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2014-SV1-unicode-passwords/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2014-SV2-empty-passwords/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2014-SV3-csrf/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2014-SV4-poodle/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2016-SV1-cleanse/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2016-SV2-share/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2017-SV1-filename/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2017-SV2-edit-rw/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/secvuln/2017-SV3-delete-script/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2012-SV1-ldap-authentication/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2014-SV1-unicode-passwords/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2014-SV2-empty-passwords/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2014-SV3-csrf/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2014-SV4-poodle/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2016-SV1-cleanse/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2016-SV2-share/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2017-SV1-filename/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2017-SV2-edit-rw/
- https://ome-www-dev.openmicroscopy.org/info/vulnerabilities/2017-SV3-delete-script/
- https://ome-www-dev.openmicroscopy.org/site/products/omero/downloads
- https://ome-www-dev.openmicroscopy.org/site/products/bio-formats/downloads

or using the tests. With this PR, the following should pass

```
pip install -r ansible/server-state-playbooks/www/tests/requirements.txt
HOST=https://ome-www-dev.openmicroscopy.org pytest ansible/server-state-playbooks/www/tests/check_redirects.py
```

## Future work

While adding the tests, I realized some of our redirects do not include trailing slashes. These redirects can be fixed in a follow-up PRs with the corresponding test changes.