### PR TITLE
Update Sphinx version to 1.6.3

### DIFF
--- a/ansible/roles/sphinx-build/tasks/main.yml
+++ b/ansible/roles/sphinx-build/tasks/main.yml
@@ -10,4 +10,4 @@
     version: "{{ item.version }}"
   with_items:
     - name: sphinx
-      version: 1.2.3
+      version: 1.6.3


### PR DESCRIPTION
See https://trello.com/c/ccx2knE7/68-check-whether-sphinx-can-be-upgraded-for-all-docs-jobs