### PR TITLE
Prefix decoupled Ansible roles with openmicroscopy.

### DIFF
--- a/ansible/ci-deployment.yml
+++ b/ansible/ci-deployment.yml
@@ -4,9 +4,9 @@
 - hosts: ci-jenkins-linux
   roles:
     - role: jenkinsslave
-    - role: sudoers
-    - role: versioncontrol-utils
-    - role: system-monitor-agent
+    - role: openmicroscopy.sudoers
+    - role: openmicroscopy.versioncontrol-utils
+    - role: openmicroscopy.system-monitor-agent
 
 # Deploy OMERO build and runtime prerequisites
 - hosts: ci-omero
@@ -14,7 +14,7 @@
     - role: omero-build
     - role: omero-runtime
 #    - role: omero-build-cpp
-    - role: postgresql
+    - role: openmicroscopy.postgresql
       postgresql_server_listen: "'*'"
       postgresql_server_auth:
       - database: all
@@ -35,8 +35,8 @@
 - hosts: ci-omero-web
   roles:
     - role: omero-runtime
-    - role: omero-web-runtime
-    - role: nginx
+    - role: openmicroscopy.omero-web-runtime
+    - role: openmicroscopy.nginx
 
 # Deploy C++ build dependencies
 - hosts: cowfish.openmicroscopy.org
@@ -47,4 +47,5 @@
 - hosts: ci-docs
   roles:
     - role: sphinx-build
+      tags: sphinx
     - role: ansible

--- a/ansible/roles/jenkinsslave/meta/main.yml
+++ b/ansible/roles/jenkinsslave/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 dependencies:
-- { role: java }
-- { role: basedeps }
+- { role: openmicroscopy.java }
+- { role: openmicroscopy.basedeps }

--- a/ansible/roles/omero-build/meta/main.yml
+++ b/ansible/roles/omero-build/meta/main.yml
@@ -1,5 +1,5 @@
 ---
 dependencies:
-- { role: basedeps }
-- { role: java }
-- { role: ice }
+- { role: openmicroscopy.basedeps }
+- { role: openmicroscopy.java }
+- { role: openmicroscopy.ice }

--- a/ansible/roles/omero-runtime/meta/main.yml
+++ b/ansible/roles/omero-runtime/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-- { role: basedeps }
-- { role: java }
-- { role: omero-python-deps }
-- { role: ice }
+- { role: openmicroscopy.basedeps }
+- { role: openmicroscopy.java }
+- { role: openmicroscopy.omero-python-deps }
+- { role: openmicroscopy.ice }


### PR DESCRIPTION
Companion PR to https://github.com/openmicroscopy/infrastructure/pull/307

While trying to deploy the Sphinx changes on the ci-docs nodes, I encountered execution issues while trying to execute the ci-deloyment playbook.

This commit prefixes all roles installed via Galaxy with openmicroscopy. It also adds a tag to the Sphinx role as this was the only required change in that case.
