### PR TITLE
Update exe4j version

### DIFF
--- a/ansible/roles/omero-build/tasks/main.yml
+++ b/ansible/roles/omero-build/tasks/main.yml
@@ -91,13 +91,15 @@
 - name: exe4j packages | install
   become: yes
   yum:
-    name: http://download-aws.ej-technologies.com/exe4j/exe4j_linux_6_0.rpm 
+    name: http://download-aws.ej-technologies.com/exe4j/exe4j_linux_6_0.rpm
     state: present
+  tags: [exe4j]
 
 - name: exe4j packages | install license
   become: yes
-  command: exe4jc -L="{{ exe4j_license_key }}"
-  when: exe4j_license_key
+  shell: env PATH=/opt/hudson/tools/hudson.model.JDK/8_LATEST/bin/:$PATH /opt/exe4j/bin/exe4jc -L="{{ exe4j_license_key }}"
+  when: exe4j_license_key is defined
+  tags: [exe4j]
 
 - name: findbugs | download and extract
   become: yes

--- a/ansible/roles/omero-build/tasks/main.yml
+++ b/ansible/roles/omero-build/tasks/main.yml
@@ -91,7 +91,7 @@
 - name: exe4j packages | install
   become: yes
   yum:
-    name: http://download-aws.ej-technologies.com/exe4j/exe4j_linux_5_0_1.rpm
+    name: http://download-aws.ej-technologies.com/exe4j/exe4j_linux_6_0.rpm 
     state: present
 
 - name: exe4j packages | install license


### PR DESCRIPTION
Use the latest version 6 of exe4j to support Java 9.

Test: Check Importer and/or Insight exe on Windows with Java 9 installed.
